### PR TITLE
fix(a11y): safe fixes — dead SW removal, real skip-link, 404 redesign, AA contrast

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -159,25 +159,9 @@
                 document.body.classList.add("loaded");
             });
 
-            // Service Worker registration para PWA
-            if ("serviceWorker" in navigator) {
-                window.addEventListener("load", function () {
-                    navigator.serviceWorker
-                        .register("/service-worker.js")
-                        .then(function (registration) {
-                            console.log(
-                                "SW registrado con éxito:",
-                                registration.scope
-                            );
-                        })
-                        .catch(function (registrationError) {
-                            console.log(
-                                "SW falló en el registro:",
-                                registrationError
-                            );
-                        });
-                });
-            }
+            // Nota: el registro del Service Worker se removió porque no existe
+            // un service-worker.js real (fallaba en cada carga). Se reintroducirá
+            // junto con una implementación real (ver backlog PR10+).
         </script>
     </body>
 </html>

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -34,6 +34,10 @@ export const Layout = ({ children, title, description }) => {
         />
       </Helmet>
 
+      <a href="#main-content" className="skip-link">
+        Ir al contenido principal
+      </a>
+
       <Header role="banner">
         {title && (
           <Title id="page-title" tabIndex="-1">

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -34,10 +34,6 @@ export const Layout = ({ children, title, description }) => {
         />
       </Helmet>
 
-      <a href="#main-content" className="skip-link">
-        Ir al contenido principal
-      </a>
-
       <Header role="banner">
         {title && (
           <Title id="page-title" tabIndex="-1">

--- a/src/components/NavBar/styles.js
+++ b/src/components/NavBar/styles.js
@@ -80,7 +80,9 @@ export const NavLink = styled(NavLinkRouter)`
   /* Estado activo con mejor contraste - React Router v6 */
   &.active {
     color: var(--color-actived);
-    background: rgba(5, 150, 105, 0.1);
+    /* rgb(4, 120, 87) = #047857, el nuevo valor de --color-actived (antes
+       rgba(5, 150, 105, 0.1) quedó desalineado tras oscurecer el token) */
+    background: rgba(4, 120, 87, 0.1);
     font-weight: 600;
 
     &::after {

--- a/src/pages/NoMatch.js
+++ b/src/pages/NoMatch.js
@@ -1,5 +1,78 @@
-import React from 'react'
+import React from "react";
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+import { Layout } from "../components/Layout";
+
+const NoMatchContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: var(--spacing-2xl) var(--spacing-md);
+  gap: var(--spacing-md);
+`;
+
+const NoMatchTitle = styled.h2`
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  color: var(--color-primary);
+`;
+
+const NoMatchText = styled.p`
+  font-size: var(--font-size-base);
+  color: var(--color-secondary);
+  line-height: 1.6;
+  max-width: 480px;
+`;
+
+const HomeLink = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  min-width: 44px;
+  padding: var(--spacing-sm) var(--spacing-xl);
+  margin-top: var(--spacing-sm);
+  /* #1d4ed8 (no var(--color-accent)) porque texto blanco sobre
+     var(--color-accent) mide solo 3.68:1 y falla WCAG AA. Texto blanco
+     sobre #1d4ed8 = 6.70:1, cumple AA (mínimo 4.5:1). */
+  background: #1d4ed8;
+  color: white;
+  font-weight: 600;
+  font-size: var(--font-size-base);
+  border-radius: var(--border-radius);
+  text-decoration: none;
+  transition: background 0.2s ease;
+
+  &:hover,
+  &:focus {
+    /* var(--color-actived) = #047857; blanco sobre #047857 = 5.48:1, AA ok */
+    background: var(--color-actived);
+    text-decoration: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-actived);
+    outline-offset: 2px;
+  }
+`;
 
 export const NoMatch = () => (
-  <h1>Esta página no existe! 😬</h1>
-)
+  <Layout
+    title="Página no encontrada"
+    description="La página que buscas no existe o fue movida."
+  >
+    <NoMatchContainer>
+      <NoMatchTitle>No encontramos esta página</NoMatchTitle>
+      <NoMatchText>
+        La página que buscas no existe o cambió de dirección. Puedes regresar
+        al inicio para seguir consultando tus horarios y procedimientos.
+      </NoMatchText>
+      <HomeLink to="/">Ir al inicio</HomeLink>
+    </NoMatchContainer>
+  </Layout>
+);

--- a/src/pages/NoMatch.js
+++ b/src/pages/NoMatch.js
@@ -50,8 +50,11 @@ const HomeLink = styled(Link)`
 
   &:hover,
   &:focus {
-    /* var(--color-actived) = #047857; blanco sobre #047857 = 5.48:1, AA ok */
-    background: var(--color-actived);
+    /* #047857 fijo (no var(--color-actived)) porque en modo oscuro el token
+       cambia a #34d399 (necesario para texto legible sobre --body-card) y
+       texto blanco sobre #34d399 mide solo 1.92:1, muy por debajo de AA.
+       Texto blanco sobre #047857 = 5.48:1 y no varía por color-scheme. */
+    background: #047857;
     text-decoration: none;
   }
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -10,6 +10,9 @@ import { NoMatch } from '../pages/NoMatch'
 export const AppRoutes = () => {
   return (
     <BrowserRouter>
+      <a href='#main-content' className='skip-link'>
+        Ir al contenido principal
+      </a>
       <NavBar />
       <Routes>
         <Route path='/' element={<Home />} />

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -209,6 +209,11 @@ export const GlobalStyle = createGlobalStyle`
       --color-secondary: #94a3b8;
       --color-tertiary: #64748b;
       --border-color: #334155;
+      /* --color-actived (#047857) sobre --body-card/--body-footer (#1e293b)
+         mide solo 2.67:1 en modo oscuro, falla WCAG AA. #34d399 (emerald-400)
+         sobre #1e293b = 7.61:1 y sobre --body-background #0f172a = 9.29:1,
+         ambos cumplen AA (mínimo 4.5:1) con margen. */
+      --color-actived: #34d399;
     }
   }
 

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -10,7 +10,9 @@ export const GlobalStyle = createGlobalStyle`
     --color-primary: #1e293b;
     --color-secondary: #64748b;
     --color-tertiary: #94a3b8;
-    --color-actived: #059669;
+    /* #047857 sobre blanco (#ffffff) = 5.48:1, cumple WCAG AA para texto normal
+       (mínimo 4.5:1). El valor previo #059669 medía 3.77:1 y fallaba AA. */
+    --color-actived: #047857;
     --color-accent: #3b82f6;
     --color-warning: #dc2626;
     --color-success: #16a34a;

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -157,13 +157,17 @@ export const GlobalStyle = createGlobalStyle`
     position: absolute;
     top: -40px;
     left: 6px;
-    background: var(--color-accent);
+    /* #1d4ed8 (no var(--color-accent)) sobre blanco de fondo: texto blanco
+       sobre #1d4ed8 = 6.70:1, cumple WCAG AA (mínimo 4.5:1). Usar
+       var(--color-accent) aquí daría solo 3.68:1 y fallaría AA. */
+    background: #1d4ed8;
     color: white;
     padding: 8px;
     text-decoration: none;
     z-index: 9999;
     border-radius: 4px;
-    
+    font-weight: 600;
+
     &:focus {
       top: 6px;
     }


### PR DESCRIPTION
Part of #3 (PR1 of the accessible-redesign chain — stacked to main)

## Summary

- Removes the dead `navigator.serviceWorker.register()` call (no `service-worker.js` exists; it errored on every page load)
- Renders a real skip-link as the first focusable element in the document (previously the `.skip-link` CSS existed but no element used it)
- Redesigns the 404 page: uses `Layout`, plain-language es-MX copy, styled "Ir al inicio" action with ≥44px touch target
- WCAG AA contrast pass on touched tokens, light AND dark mode, with measured ratios

## Changes

| File | Change |
|------|--------|
| `public/index.html` | Dead service-worker registration removed |
| `src/routes/index.js` | Skip-link rendered at document root, above `<NavBar />` (genuine first tab stop) |
| `src/components/Layout/index.js` | Keeps the `#main-content` target; skip-link moved out |
| `src/pages/NoMatch.js` | Full 404 redesign; hover background pinned to mode-invariant `#047857` |
| `src/styles/GlobalStyle.js` | `--color-actived` #059669 → #047857 (light), dark-mode override #34d399 added |
| `src/components/NavBar/styles.js` | Active-tab tint reconciled with the darkened token |

## Measured contrast ratios (WCAG relative luminance)

| Pair | Before | After |
|------|--------|-------|
| `--color-actived` on white (light) | 3.77:1 ✗ | 5.48:1 ✓ |
| `--color-actived` on `#1e293b` (dark, cards) | 3.88:1 ✗ | 7.61:1 ✓ |
| `--color-actived` on `#0f172a` (dark, body) | — | 9.29:1 ✓ |
| Skip-link / 404 button text on `#1d4ed8` | — | 6.70:1 ✓ |

## Test plan

- [x] `npm run build` passes (only pre-existing asset-size warnings, identical on main)
- [x] Independent fresh-context review of the full diff (two critical findings caught and fixed: skip-link DOM order, dark-mode token override)
- [ ] Manual check on a real browser recommended: Tab as first action focuses the skip-link; `/does-not-exist` shows the new 404

## Known follow-ups (tracked in #3, out of PR1 scope)

- `ProgressStep` CompleteButton: white text on `var(--color-actived)` fails in dark mode (pre-existing) — scheduled for PR2/PR5
- `var(--color-accent)` (#3b82f6) as white-text background fails AA in pre-existing untouched components — scheduled for the PR5 token pass