### PR TITLE
feat(nav): hub Home, grouped navigation with visible labels, new section routes

### DIFF
--- a/__tests__/Home.test.js
+++ b/__tests__/Home.test.js
@@ -1,0 +1,61 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { Home } from '../src/pages/Home'
+
+const renderHome = () =>
+  render(
+    <MemoryRouter>
+      <Home />
+    </MemoryRouter>
+  )
+
+// Home becomes a hub with 3 distinct grouped sections; daily schedules stay
+// below the hub — R4.1.
+describe('Home', () => {
+  it('renders the 3 hub sections with distinct headings', () => {
+    renderHome()
+
+    expect(
+      screen.getByRole('heading', { name: /Procedimientos/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /Higiene y señales de alarma/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /Comida y líquidos/ })
+    ).toBeInTheDocument()
+  })
+
+  it('links each procedure card to its legacy route', () => {
+    renderHome()
+
+    expect(screen.getByRole('link', { name: /Aseo General/ })).toHaveAttribute(
+      'href',
+      '/aseo-general'
+    )
+    expect(
+      screen.getByRole('link', { name: /Limpieza de Herida/ })
+    ).toHaveAttribute('href', '/limpieza-herida')
+    expect(
+      screen.getByRole('link', { name: /Realizar Diálisis/ })
+    ).toHaveAttribute('href', '/realizar-dialisis')
+  })
+
+  it('keeps the daily schedules below the hub sections', () => {
+    renderHome()
+
+    const headings = screen.getAllByRole('heading', { level: 2 })
+    const headingText = headings.map((heading) => heading.textContent)
+
+    const lastHubIndex = headingText.findIndex((text) =>
+      text.includes('Comida y líquidos')
+    )
+    const firstScheduleIndex = headingText.findIndex((text) =>
+      text.includes('Horario sugerido diario')
+    )
+
+    expect(lastHubIndex).toBeGreaterThan(-1)
+    expect(firstScheduleIndex).toBeGreaterThan(lastHubIndex)
+  })
+})

--- a/__tests__/NavBar.test.js
+++ b/__tests__/NavBar.test.js
@@ -1,0 +1,87 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { NavBar } from '../src/components/NavBar'
+
+const renderNavBar = (initialPath) =>
+  render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <NavBar />
+    </MemoryRouter>
+  )
+
+describe('NavBar', () => {
+  it('renders the 4 group tabs with visible text labels', () => {
+    renderNavBar('/')
+
+    // Visible labels (not sr-only) — R4.2: low-literacy users navigate by
+    // icon + word, so the label text must be real rendered content.
+    expect(screen.getByText('Inicio')).toBeVisible()
+    expect(screen.getByText('Procedimientos')).toBeVisible()
+    expect(screen.getByText('Cuidados')).toBeVisible()
+    expect(screen.getByText('Comida y líquidos')).toBeVisible()
+  })
+
+  it('marks only Inicio active on the home route', () => {
+    renderNavBar('/')
+
+    expect(screen.getByRole('link', { name: /Inicio/ })).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
+    expect(
+      screen.getByRole('link', { name: /Procedimientos/ })
+    ).not.toHaveAttribute('aria-current')
+  })
+
+  it('marks Procedimientos active on a legacy procedure route', () => {
+    renderNavBar('/aseo-general')
+
+    expect(
+      screen.getByRole('link', { name: /Procedimientos/ })
+    ).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('link', { name: /^Inicio/ })).not.toHaveAttribute(
+      'aria-current'
+    )
+  })
+
+  it('marks Procedimientos active on the new /procedimientos index route', () => {
+    renderNavBar('/procedimientos')
+
+    expect(
+      screen.getByRole('link', { name: /Procedimientos/ })
+    ).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('marks Cuidados active on a nested /cuidados/* topic route', () => {
+    renderNavBar('/cuidados/senales-de-alarma')
+
+    expect(screen.getByRole('link', { name: /Cuidados/ })).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
+  })
+
+  it('marks Comida y líquidos active on a nested /alimentacion/* topic route', () => {
+    renderNavBar('/alimentacion/nutricion')
+
+    expect(
+      screen.getByRole('link', { name: /Comida y líquidos/ })
+    ).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('does not mark any tab active on an unrelated route', () => {
+    renderNavBar('/does-not-exist')
+
+    for (const name of [
+      /^Inicio/,
+      /Procedimientos/,
+      /Cuidados/,
+      /Comida y líquidos/
+    ]) {
+      expect(screen.getByRole('link', { name })).not.toHaveAttribute(
+        'aria-current'
+      )
+    }
+  })
+})

--- a/__tests__/RouteList.test.js
+++ b/__tests__/RouteList.test.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { RouteList } from '../src/routes/RouteList'
+
+const renderAt = (path) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <RouteList />
+    </MemoryRouter>
+  )
+
+// Every route in this suite renders through Layout, whose <main id="main-content">
+// landmark is the target of the skip-link (routes/index.js) — R6.2. Asserting
+// the landmark exists on each new route is the pragmatic proxy for "renders
+// correctly under Layout" without duplicating Layout's own rendering details.
+describe('RouteList', () => {
+  it('renders Home at /', () => {
+    renderAt('/')
+    expect(screen.getByRole('main')).toBeInTheDocument()
+  })
+
+  it.each([
+    ['/aseo-general', 'Aseo General'],
+    ['/limpieza-herida', 'Limpieza de Herida'],
+    ['/realizar-dialisis', 'Realizar Diálisis']
+  ])('keeps the legacy procedure route %s working', (path, heading) => {
+    renderAt(path)
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(screen.getAllByText(heading, { exact: false }).length).toBeGreaterThan(0)
+  })
+
+  it.each([
+    ['/procedimientos', 'Procedimientos'],
+    ['/cuidados', 'Higiene y señales de alarma'],
+    ['/alimentacion', 'Comida y líquidos']
+  ])('renders the new index page at %s under Layout', (path, headingText) => {
+    renderAt(path)
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(screen.getAllByText(headingText, { exact: false }).length).toBeGreaterThan(0)
+  })
+
+  it.each([
+    '/cuidados/higiene',
+    '/cuidados/senales-de-alarma',
+    '/alimentacion/liquidos',
+    '/alimentacion/nutricion'
+  ])('renders the topic placeholder at %s under Layout', (path) => {
+    renderAt(path)
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(screen.getByText(/preparando esta guía/)).toBeInTheDocument()
+  })
+
+  it('falls back to NoMatch on an unknown route', () => {
+    renderAt('/does-not-exist')
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(screen.getByText(/No encontramos esta página/)).toBeInTheDocument()
+  })
+})

--- a/src/components/CardLink/index.js
+++ b/src/components/CardLink/index.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import {
+  CardLinkElement,
+  CardLinkIcon,
+  CardLinkBody,
+  CardLinkTitle,
+  CardLinkDescription
+} from './styles'
+
+export { CardLinkGrid } from './styles'
+
+// Big icon+text card used by the Home hub sections and the 3 group index
+// pages (/procedimientos, /cuidados, /alimentacion) — R4.1, R4.2.
+export const CardLink = ({ to, icon: Icon, title, description }) => (
+  <CardLinkElement to={to}>
+    <CardLinkIcon aria-hidden='true'>
+      <Icon size='32px' />
+    </CardLinkIcon>
+    <CardLinkBody>
+      <CardLinkTitle>{title}</CardLinkTitle>
+      {description && <CardLinkDescription>{description}</CardLinkDescription>}
+    </CardLinkBody>
+  </CardLinkElement>
+)

--- a/src/components/CardLink/styles.js
+++ b/src/components/CardLink/styles.js
@@ -1,0 +1,76 @@
+import styled from 'styled-components'
+import { Link } from 'react-router-dom'
+
+export const CardLinkGrid = styled.ul`
+  list-style: none;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-md);
+  margin: 0;
+  padding: 0;
+  width: 100%;
+
+  @media (min-width: 640px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+`
+
+export const CardLinkElement = styled(Link)`
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  min-height: 44px; /* Área de toque mínima accesible — R6.3 */
+  height: 100%;
+  padding: var(--spacing-md) var(--spacing-lg);
+  border-radius: var(--border-radius);
+  background: var(--body-card);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-light);
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+
+  &:hover,
+  &:focus {
+    box-shadow: var(--shadow-medium);
+    transform: translateY(-1px);
+    text-decoration: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:hover {
+      transform: none;
+    }
+  }
+`
+
+export const CardLinkIcon = styled.span`
+  flex-shrink: 0;
+  display: inline-flex;
+  color: var(--color-accent);
+`
+
+export const CardLinkBody = styled.span`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`
+
+export const CardLinkTitle = styled.strong`
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  color: var(--color-primary);
+`
+
+export const CardLinkDescription = styled.span`
+  font-size: var(--font-size-sm);
+  color: var(--color-secondary);
+  line-height: 1.4;
+`

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -1,54 +1,85 @@
 import React from 'react'
-import { Nav, NavLink } from './styles'
-import { MdHome } from 'react-icons/md'
-import {
-  GiVacuumCleaner,
-  GiRoughWound,
-  GiWaterRecycling
-} from 'react-icons/gi'
+import { useLocation } from 'react-router-dom'
+import { Nav, NavLink, NavLabel } from './styles'
+import { MdHome, MdChecklist, MdHealthAndSafety, MdRestaurant } from 'react-icons/md'
+
+// 4 grupos de navegación (R4.1, R4.2, R4.3 del diseño): el hub de Inicio
+// absorbe la navegación secundaria, así la barra se mantiene en 4 pestañas
+// de nivel superior incluso cuando el contenido crece (higiene, alimentación,
+// etc. viven dentro de estos grupos en lugar de sumar pestañas nuevas).
+//
+// "Procedimientos" incluye las URLs legacy de los 3 procedimientos
+// (/aseo-general, /limpieza-herida, /realizar-dialisis) para que la pestaña
+// se marque activa aunque esas rutas no vivan bajo /procedimientos — las
+// URLs legacy no cambian (progreso guardado, analítica) pero conceptualmente
+// pertenecen al grupo Procedimientos.
+const NAV_ITEMS = [
+  {
+    to: '/',
+    label: 'Inicio',
+    ariaLabel: 'Inicio - Horarios de diálisis',
+    Icon: MdHome,
+    prefixes: ['/']
+  },
+  {
+    to: '/procedimientos',
+    label: 'Procedimientos',
+    ariaLabel: 'Procedimientos - Aseo, curación y diálisis',
+    Icon: MdChecklist,
+    prefixes: [
+      '/procedimientos',
+      '/aseo-general',
+      '/limpieza-herida',
+      '/realizar-dialisis'
+    ]
+  },
+  {
+    to: '/cuidados',
+    label: 'Cuidados',
+    ariaLabel: 'Cuidados - Higiene y señales de alarma',
+    Icon: MdHealthAndSafety,
+    prefixes: ['/cuidados']
+  },
+  {
+    to: '/alimentacion',
+    label: 'Comida y líquidos',
+    ariaLabel: 'Comida y líquidos',
+    Icon: MdRestaurant,
+    prefixes: ['/alimentacion']
+  }
+]
+
+// Coincidencia por prefijo (no exacta): una pestaña se marca activa si la
+// ruta actual es exactamente su prefijo o un descendiente de él — R4.2.
+const isPrefixActive = (pathname, prefixes) =>
+  prefixes.some((prefix) =>
+    prefix === '/'
+      ? pathname === '/'
+      : pathname === prefix || pathname.startsWith(`${prefix}/`)
+  )
 
 export const NavBar = () => {
+  const { pathname } = useLocation()
+
   return (
     <Nav role='navigation' aria-label='Navegación principal'>
-      <NavLink
-        exact
-        to='/'
-        aria-label='Inicio - Horarios de diálisis'
-        title='Inicio'
-      >
-        <MdHome size='32px' aria-hidden='true' />
-        <span className='sr-only'>Inicio</span>
-      </NavLink>
+      {NAV_ITEMS.map(({ to, label, ariaLabel, Icon, prefixes }) => {
+        const isActive = isPrefixActive(pathname, prefixes)
 
-      <NavLink
-        exact
-        to='/aseo-general'
-        aria-label='Aseo general - Limpieza del área'
-        title='Aseo general'
-      >
-        <GiVacuumCleaner size='32px' aria-hidden='true' />
-        <span className='sr-only'>Aseo general</span>
-      </NavLink>
-
-      <NavLink
-        exact
-        to='/limpieza-herida'
-        aria-label='Limpieza de herida - Curación'
-        title='Limpieza de herida'
-      >
-        <GiRoughWound size='32px' aria-hidden='true' />
-        <span className='sr-only'>Limpieza de herida</span>
-      </NavLink>
-
-      <NavLink
-        exact
-        to='/realizar-dialisis'
-        aria-label='Realizar diálisis - Proceso completo'
-        title='Realizar diálisis'
-      >
-        <GiWaterRecycling size='32px' aria-hidden='true' />
-        <span className='sr-only'>Realizar diálisis</span>
-      </NavLink>
+        return (
+          <NavLink
+            key={to}
+            to={to}
+            className={isActive ? 'active' : undefined}
+            aria-current={isActive ? 'page' : undefined}
+            aria-label={ariaLabel}
+            title={label}
+          >
+            <Icon size='28px' aria-hidden='true' />
+            <NavLabel>{label}</NavLabel>
+          </NavLink>
+        )
+      })}
     </Nav>
   )
 }

--- a/src/components/NavBar/styles.js
+++ b/src/components/NavBar/styles.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { NavLink as NavLinkRouter } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { fadeIn } from '../../styles/animation'
 
 export const Nav = styled.nav`
@@ -11,9 +11,13 @@ export const Nav = styled.nav`
   align-items: center;
   margin: 0 auto;
   padding: var(--spacing-xs);
-  justify-content: space-around;
+  justify-content: space-between;
   width: 100%;
-  height: var(--footer-height);
+  /* min-height (no height) — con etiquetas de texto visibles (R4.2) el
+     contenido puede envolver a 2 líneas en pantallas angostas; usar una
+     altura fija recortaría el texto. min-height respeta el piso del token
+     y crece si el contenido lo necesita — R6.3. */
+  min-height: var(--footer-height);
   border-top: 1px solid var(--border-color);
   background-color: var(--body-footer);
   backdrop-filter: blur(10px);
@@ -50,14 +54,18 @@ export const Nav = styled.nav`
   }
 `
 
-export const NavLink = styled(NavLinkRouter)`
+export const NavLink = styled(Link)`
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-direction: column;
+  /* Los 4 grupos se reparten el ancho de forma pareja y nunca se recortan
+     ni se salen del contenedor, ni siquiera en 360px de ancho — R4.2. */
+  flex: 1 1 0;
+  min-width: 0;
+  max-width: 25%;
   padding: var(--spacing-sm);
   min-height: 48px; /* Área de toque mínima accesible */
-  min-width: 48px;
   color: var(--color-secondary);
   text-decoration: none;
   border-radius: var(--border-radius);
@@ -77,7 +85,7 @@ export const NavLink = styled(NavLinkRouter)`
     background: rgba(59, 130, 246, 0.1);
   }
 
-  /* Estado activo con mejor contraste - React Router v6 */
+  /* Estado activo con mejor contraste - coincidencia por prefijo, no exacta */
   &.active {
     color: var(--color-actived);
     /* rgb(4, 120, 87) = #047857, el nuevo valor de --color-actived (antes
@@ -103,6 +111,7 @@ export const NavLink = styled(NavLinkRouter)`
   svg {
     margin-bottom: 2px;
     transition: transform 0.2s ease;
+    flex-shrink: 0;
   }
 
   &:hover svg,
@@ -110,39 +119,14 @@ export const NavLink = styled(NavLinkRouter)`
     transform: scale(1.1);
   }
 
-  /* Labels accesibles (ocultos visualmente pero disponibles para lectores de pantalla) */
-  &::before {
-    content: attr(aria-label);
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    background: var(--color-primary);
-    color: var(--body-background);
-    padding: 4px 8px;
-    border-radius: 4px;
-    font-size: var(--font-size-sm);
-    white-space: nowrap;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.2s ease;
-    z-index: 1001;
-  }
-
-  &:hover::before,
-  &:focus::before {
-    opacity: 1;
-  }
-
   /* Responsive para pantallas pequeñas */
   @media (max-width: 480px) {
     padding: var(--spacing-xs);
     min-height: 44px;
-    min-width: 44px;
 
     svg {
-      width: 24px !important;
-      height: 24px !important;
+      width: 22px !important;
+      height: 22px !important;
     }
   }
 
@@ -153,18 +137,6 @@ export const NavLink = styled(NavLinkRouter)`
     svg {
       width: 28px !important;
       height: 28px !important;
-    }
-  }
-
-  /* Modo oscuro */
-  @media (prefers-color-scheme: dark) {
-    &::before {
-      background: var(--body-background);
-      color: var(--color-primary);
-    }
-
-    &.active::after {
-      background: var(--color-actived);
     }
   }
 
@@ -185,4 +157,17 @@ export const NavLink = styled(NavLinkRouter)`
       transform: none;
     }
   }
+`
+
+export const NavLabel = styled.span`
+  /* Etiqueta corta y visible bajo el ícono (antes sr-only) — navegación
+     por ícono + palabra para usuarios de baja alfabetización — R4.2. */
+  display: block;
+  font-size: clamp(9px, 2.4vw, 11px);
+  line-height: 1.15;
+  text-align: center;
+  width: 100%;
+  overflow-wrap: break-word;
+  hyphens: auto;
+  color: inherit;
 `

--- a/src/components/PageContainer/index.js
+++ b/src/components/PageContainer/index.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import { PageContainerElement } from './styles'
+
+// Shared centered/max-width wrapper for pages built from multiple stacked
+// Cards (index pages, topic placeholders) — same layout Home already used
+// inline, extracted so new pages don't duplicate it.
+export const PageContainer = ({ children }) => (
+  <PageContainerElement>{children}</PageContainerElement>
+)

--- a/src/components/PageContainer/styles.js
+++ b/src/components/PageContainer/styles.js
@@ -1,0 +1,20 @@
+import styled from 'styled-components'
+
+export const PageContainerElement = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 var(--spacing-md);
+
+  @media (max-width: 768px) {
+    padding: 0 var(--spacing-sm);
+    max-width: 100%;
+  }
+
+  @media (min-width: 1024px) {
+    max-width: 900px;
+  }
+`

--- a/src/components/ProgressStep/styles.js
+++ b/src/components/ProgressStep/styles.js
@@ -335,15 +335,24 @@ const ButtonBase = styled.button`
 `;
 
 export const CompleteButton = styled(ButtonBase)`
-  background: var(--color-actived);
+  /* #047857 fijo (no var(--color-actived)) — mismo patrón que HomeLink en
+     NoMatch.js (PR1). En modo oscuro el token cambia a #34d399 (necesario
+     para texto legible sobre --body-card), y texto blanco sobre #34d399
+     mide solo 1.92:1, muy por debajo de AA. Texto blanco sobre #047857 =
+     5.48:1 y no varía por color-scheme. Carried as a known follow-up risk
+     through PR1/PR2/PR3/PR4a/PR4b, fixed here in PR5a — R6.1. */
+  background: #047857;
   color: white;
 
   &:hover {
-    background: var(--color-success);
+    /* #065f46 fijo, mismo motivo: var(--color-success) (#16a34a) con texto
+       blanco mide solo 3.30:1 y falla AA; #065f46 con texto blanco = 7.68:1
+       y no varía por color-scheme. */
+    background: #065f46;
   }
 
   &:focus {
-    outline-color: var(--color-actived);
+    outline-color: #047857;
   }
 `;
 

--- a/src/content/navigation.js
+++ b/src/content/navigation.js
@@ -1,0 +1,66 @@
+import {
+  GiVacuumCleaner,
+  GiRoughWound,
+  GiWaterRecycling,
+  GiMedicines,
+  GiWaterDrop,
+  GiFruitBowl
+} from 'react-icons/gi'
+import { MdWarningAmber } from 'react-icons/md'
+import { aseoGeneral } from './procedures/aseo-general'
+import { limpiezaHerida } from './procedures/limpieza-herida'
+import { realizarDialisis } from './procedures/realizar-dialisis'
+
+// Data for the hub Home sections and the 3 group index pages
+// (/procedimientos, /cuidados, /alimentacion) — R4.1, R4.2. Single-sourced
+// here so Home and each index page never drift on titles/descriptions.
+export const procedureLinks = [
+  {
+    to: aseoGeneral.route,
+    title: aseoGeneral.title,
+    description: aseoGeneral.description,
+    icon: GiVacuumCleaner
+  },
+  {
+    to: limpiezaHerida.route,
+    title: limpiezaHerida.title,
+    description: limpiezaHerida.description,
+    icon: GiRoughWound
+  },
+  {
+    to: realizarDialisis.route,
+    title: realizarDialisis.title,
+    description: realizarDialisis.description,
+    icon: GiWaterRecycling
+  }
+]
+
+export const cuidadosLinks = [
+  {
+    to: '/cuidados/higiene',
+    title: 'Higiene',
+    description: 'Cuidado de la piel, el catéter y la herida.',
+    icon: GiMedicines
+  },
+  {
+    to: '/cuidados/senales-de-alarma',
+    title: 'Señales de alarma',
+    description: 'Qué observar y cuándo buscar ayuda.',
+    icon: MdWarningAmber
+  }
+]
+
+export const alimentacionLinks = [
+  {
+    to: '/alimentacion/liquidos',
+    title: 'Líquidos',
+    description: 'Qué tomar en cuenta sobre líquidos e ingresos.',
+    icon: GiWaterDrop
+  },
+  {
+    to: '/alimentacion/nutricion',
+    title: 'Nutrición',
+    description: 'Alimentación saludable para diálisis peritoneal.',
+    icon: GiFruitBowl
+  }
+]

--- a/src/pages/AlimentacionIndex.js
+++ b/src/pages/AlimentacionIndex.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Layout } from '../components/Layout'
+import { Card } from '../components/Card'
+import { CardLink, CardLinkGrid } from '../components/CardLink'
+import { PageContainer } from '../components/PageContainer'
+import { alimentacionLinks } from '../content/navigation'
+
+export const AlimentacionIndex = () => (
+  <Layout
+    title='Comida y líquidos'
+    description='Qué tomar en cuenta sobre líquidos y alimentación en diálisis peritoneal.'
+  >
+    <PageContainer>
+      <Card>
+        <section aria-labelledby='alimentacion-heading'>
+          <h2 id='alimentacion-heading'>🍽️ Comida y líquidos</h2>
+          <p>
+            Consulta información sobre líquidos, ingresos y una alimentación
+            saludable durante la diálisis peritoneal.
+          </p>
+        </section>
+      </Card>
+      <CardLinkGrid aria-label='Lista de temas de alimentación'>
+        {alimentacionLinks.map((link) => (
+          <li key={link.to}>
+            <CardLink {...link} />
+          </li>
+        ))}
+      </CardLinkGrid>
+    </PageContainer>
+  </Layout>
+)

--- a/src/pages/CuidadosIndex.js
+++ b/src/pages/CuidadosIndex.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Layout } from '../components/Layout'
+import { Card } from '../components/Card'
+import { CardLink, CardLinkGrid } from '../components/CardLink'
+import { PageContainer } from '../components/PageContainer'
+import { cuidadosLinks } from '../content/navigation'
+
+export const CuidadosIndex = () => (
+  <Layout
+    title='Cuidados'
+    description='Higiene, cuidado de heridas y señales de alarma en diálisis peritoneal.'
+  >
+    <PageContainer>
+      <Card>
+        <section aria-labelledby='cuidados-heading'>
+          <h2 id='cuidados-heading'>🩺 Higiene y señales de alarma</h2>
+          <p>
+            Consulta cómo cuidar tu piel y catéter, y qué señales indican que
+            debes buscar ayuda.
+          </p>
+        </section>
+      </Card>
+      <CardLinkGrid aria-label='Lista de temas de cuidados'>
+        {cuidadosLinks.map((link) => (
+          <li key={link.to}>
+            <CardLink {...link} />
+          </li>
+        ))}
+      </CardLinkGrid>
+    </PageContainer>
+  </Layout>
+)

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -2,6 +2,12 @@ import React from "react";
 import styled from "styled-components";
 import { Layout } from "../components/Layout";
 import { Card } from "../components/Card";
+import { CardLink, CardLinkGrid } from "../components/CardLink";
+import {
+  procedureLinks,
+  cuidadosLinks,
+  alimentacionLinks,
+} from "../content/navigation";
 
 const CenteredContainer = styled.div`
   display: flex;
@@ -50,6 +56,50 @@ export const Home = () => {
               Introducción
             </h2>
             <p>{description}</p>
+          </section>
+        </Card>
+
+        {/* Hub: 3 secciones agrupadas por tema (R4.1). Los horarios diarios
+            quedan debajo de estos grupos, ver más abajo. */}
+        <Card>
+          <section aria-labelledby="hub-procedimientos-heading">
+            <h2 id="hub-procedimientos-heading">🧴 Procedimientos</h2>
+            <p>Guías paso a paso para el aseo, la curación y la diálisis.</p>
+            <CardLinkGrid aria-label="Lista de procedimientos">
+              {procedureLinks.map((link) => (
+                <li key={link.to}>
+                  <CardLink {...link} />
+                </li>
+              ))}
+            </CardLinkGrid>
+          </section>
+        </Card>
+
+        <Card>
+          <section aria-labelledby="hub-cuidados-heading">
+            <h2 id="hub-cuidados-heading">🩺 Higiene y señales de alarma</h2>
+            <p>Cómo cuidar tu piel y catéter, y cuándo buscar ayuda.</p>
+            <CardLinkGrid aria-label="Lista de temas de cuidados">
+              {cuidadosLinks.map((link) => (
+                <li key={link.to}>
+                  <CardLink {...link} />
+                </li>
+              ))}
+            </CardLinkGrid>
+          </section>
+        </Card>
+
+        <Card>
+          <section aria-labelledby="hub-alimentacion-heading">
+            <h2 id="hub-alimentacion-heading">🍽️ Comida y líquidos</h2>
+            <p>Líquidos, ingresos y alimentación saludable.</p>
+            <CardLinkGrid aria-label="Lista de temas de alimentación">
+              {alimentacionLinks.map((link) => (
+                <li key={link.to}>
+                  <CardLink {...link} />
+                </li>
+              ))}
+            </CardLinkGrid>
           </section>
         </Card>
 
@@ -143,42 +193,6 @@ export const Home = () => {
                 <strong>Ingreso:</strong> 0 ml
               </li>
             </ul>
-          </section>
-        </Card>
-
-        {/* Navegación rápida a otras secciones */}
-        <Card>
-          <section aria-labelledby="quick-nav-heading">
-            <h2 id="quick-nav-heading">🔗 Acceso rápido</h2>
-            <nav aria-label="Navegación a secciones principales">
-              <ul role="list">
-                <li>
-                  <a href="/aseo-general" aria-describedby="aseo-desc">
-                    🧹 <strong>Aseo General</strong>
-                  </a>
-                  <div id="aseo-desc" className="sr-only">
-                    Instrucciones paso a paso para la limpieza del área
-                  </div>
-                </li>
-                <li>
-                  <a href="/limpieza-herida" aria-describedby="herida-desc">
-                    🩹 <strong>Limpieza de Herida</strong>
-                  </a>
-                  <div id="herida-desc" className="sr-only">
-                    Procedimientos de curación y cuidado de heridas
-                  </div>
-                </li>
-                <li>
-                  <a href="/realizar-dialisis" aria-describedby="dialisis-desc">
-                    💧 <strong>Realizar Diálisis</strong>
-                  </a>
-                  <div id="dialisis-desc" className="sr-only">
-                    Proceso completo de diálisis peritoneal con videos
-                    instructivos
-                  </div>
-                </li>
-              </ul>
-            </nav>
           </section>
         </Card>
 

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -60,48 +60,53 @@ export const Home = () => {
         </Card>
 
         {/* Hub: 3 secciones agrupadas por tema (R4.1). Los horarios diarios
-            quedan debajo de estos grupos, ver más abajo. */}
-        <Card>
-          <section aria-labelledby="hub-procedimientos-heading">
+            quedan debajo de estos grupos, ver más abajo.
+
+            CardLinkGrid vive como hermano de Card (no anidado dentro), igual
+            que en las páginas índice — el selector `a` de CardComponent
+            (0,1,1 de especificidad) pisaría los estilos propios de
+            CardLinkElement (0,1,0) si quedara anidado adentro. */}
+        <section aria-labelledby="hub-procedimientos-heading">
+          <Card>
             <h2 id="hub-procedimientos-heading">🧴 Procedimientos</h2>
             <p>Guías paso a paso para el aseo, la curación y la diálisis.</p>
-            <CardLinkGrid aria-label="Lista de procedimientos">
-              {procedureLinks.map((link) => (
-                <li key={link.to}>
-                  <CardLink {...link} />
-                </li>
-              ))}
-            </CardLinkGrid>
-          </section>
-        </Card>
+          </Card>
+          <CardLinkGrid aria-label="Lista de procedimientos">
+            {procedureLinks.map((link) => (
+              <li key={link.to}>
+                <CardLink {...link} />
+              </li>
+            ))}
+          </CardLinkGrid>
+        </section>
 
-        <Card>
-          <section aria-labelledby="hub-cuidados-heading">
+        <section aria-labelledby="hub-cuidados-heading">
+          <Card>
             <h2 id="hub-cuidados-heading">🩺 Higiene y señales de alarma</h2>
             <p>Cómo cuidar tu piel y catéter, y cuándo buscar ayuda.</p>
-            <CardLinkGrid aria-label="Lista de temas de cuidados">
-              {cuidadosLinks.map((link) => (
-                <li key={link.to}>
-                  <CardLink {...link} />
-                </li>
-              ))}
-            </CardLinkGrid>
-          </section>
-        </Card>
+          </Card>
+          <CardLinkGrid aria-label="Lista de temas de cuidados">
+            {cuidadosLinks.map((link) => (
+              <li key={link.to}>
+                <CardLink {...link} />
+              </li>
+            ))}
+          </CardLinkGrid>
+        </section>
 
-        <Card>
-          <section aria-labelledby="hub-alimentacion-heading">
+        <section aria-labelledby="hub-alimentacion-heading">
+          <Card>
             <h2 id="hub-alimentacion-heading">🍽️ Comida y líquidos</h2>
             <p>Líquidos, ingresos y alimentación saludable.</p>
-            <CardLinkGrid aria-label="Lista de temas de alimentación">
-              {alimentacionLinks.map((link) => (
-                <li key={link.to}>
-                  <CardLink {...link} />
-                </li>
-              ))}
-            </CardLinkGrid>
-          </section>
-        </Card>
+          </Card>
+          <CardLinkGrid aria-label="Lista de temas de alimentación">
+            {alimentacionLinks.map((link) => (
+              <li key={link.to}>
+                <CardLink {...link} />
+              </li>
+            ))}
+          </CardLinkGrid>
+        </section>
 
         {/* Sección de horarios de 3 recambios */}
         <Card>

--- a/src/pages/ProcedimientosIndex.js
+++ b/src/pages/ProcedimientosIndex.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Layout } from '../components/Layout'
+import { Card } from '../components/Card'
+import { CardLink, CardLinkGrid } from '../components/CardLink'
+import { PageContainer } from '../components/PageContainer'
+import { procedureLinks } from '../content/navigation'
+
+export const ProcedimientosIndex = () => (
+  <Layout
+    title='Procedimientos'
+    description='Guías paso a paso para el aseo general, la curación de heridas y la diálisis.'
+  >
+    <PageContainer>
+      <Card>
+        <section aria-labelledby='procedimientos-heading'>
+          <h2 id='procedimientos-heading'>🧴 Procedimientos</h2>
+          <p>
+            Elige el procedimiento que necesitas realizar. Cada guía te lleva
+            paso a paso, con fotos y videos.
+          </p>
+        </section>
+      </Card>
+      <CardLinkGrid aria-label='Lista de procedimientos'>
+        {procedureLinks.map((link) => (
+          <li key={link.to}>
+            <CardLink {...link} />
+          </li>
+        ))}
+      </CardLinkGrid>
+    </PageContainer>
+  </Layout>
+)

--- a/src/pages/TopicComingSoon.js
+++ b/src/pages/TopicComingSoon.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Layout } from '../components/Layout'
+import { Card } from '../components/Card'
+import { PageContainer } from '../components/PageContainer'
+
+// Minimal plain-language placeholder for topic pages not yet written
+// (PR6-9 add the real content). Still routes through Layout so the
+// skip-link/landmarks work correctly on every scaffolded URL — R6.2.
+export const TopicComingSoon = ({ title, description }) => (
+  <Layout title={title} description={description}>
+    <PageContainer>
+      <Card>
+        <section aria-labelledby='coming-soon-heading'>
+          <h2 id='coming-soon-heading'>{title}</h2>
+          {description && <p>{description}</p>}
+          <p>
+            Estamos preparando esta guía. Muy pronto encontrarás aquí
+            información clara y confiable. Mientras tanto, puedes consultar
+            tus horarios y procedimientos desde el inicio.
+          </p>
+        </section>
+      </Card>
+    </PageContainer>
+  </Layout>
+)

--- a/src/routes/RouteList.js
+++ b/src/routes/RouteList.js
@@ -1,0 +1,69 @@
+import React from 'react'
+import { Routes, Route } from 'react-router-dom'
+import { Home } from '../pages/Home'
+import { GeneralCleaning } from '../pages/GeneralCleaning'
+import { WoundHealing } from '../pages/WoundHealing'
+import { WaterRecycling } from '../pages/WaterRecycling'
+import { ProcedimientosIndex } from '../pages/ProcedimientosIndex'
+import { CuidadosIndex } from '../pages/CuidadosIndex'
+import { AlimentacionIndex } from '../pages/AlimentacionIndex'
+import { TopicComingSoon } from '../pages/TopicComingSoon'
+import { NoMatch } from '../pages/NoMatch'
+
+// Extracted from routes/index.js (which also wraps BrowserRouter + NavBar)
+// so it can be rendered under a MemoryRouter in tests without pulling in
+// the real browser history.
+export const RouteList = () => (
+  <Routes>
+    <Route path='/' element={<Home />} />
+
+    {/* Legacy procedure URLs — unchanged, R4.2 */}
+    <Route path='/aseo-general' element={<GeneralCleaning />} />
+    <Route path='/limpieza-herida' element={<WoundHealing />} />
+    <Route path='/realizar-dialisis' element={<WaterRecycling />} />
+
+    <Route path='/procedimientos' element={<ProcedimientosIndex />} />
+
+    <Route path='/cuidados' element={<CuidadosIndex />} />
+    <Route
+      path='/cuidados/higiene'
+      element={
+        <TopicComingSoon
+          title='Higiene'
+          description='Cuidado de la piel, el catéter y la herida.'
+        />
+      }
+    />
+    <Route
+      path='/cuidados/senales-de-alarma'
+      element={
+        <TopicComingSoon
+          title='Señales de alarma'
+          description='Qué observar y cuándo buscar ayuda.'
+        />
+      }
+    />
+
+    <Route path='/alimentacion' element={<AlimentacionIndex />} />
+    <Route
+      path='/alimentacion/liquidos'
+      element={
+        <TopicComingSoon
+          title='Líquidos'
+          description='Qué tomar en cuenta sobre líquidos e ingresos.'
+        />
+      }
+    />
+    <Route
+      path='/alimentacion/nutricion'
+      element={
+        <TopicComingSoon
+          title='Nutrición'
+          description='Alimentación saludable para diálisis peritoneal.'
+        />
+      }
+    />
+
+    <Route path='*' element={<NoMatch />} />
+  </Routes>
+)

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,11 +1,7 @@
 import React from 'react'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter } from 'react-router-dom'
 import { NavBar } from '../components/NavBar'
-import { Home } from '../pages/Home'
-import { GeneralCleaning } from '../pages/GeneralCleaning'
-import { WoundHealing } from '../pages/WoundHealing'
-import { WaterRecycling } from '../pages/WaterRecycling'
-import { NoMatch } from '../pages/NoMatch'
+import { RouteList } from './RouteList'
 
 export const AppRoutes = () => {
   return (
@@ -14,13 +10,7 @@ export const AppRoutes = () => {
         Ir al contenido principal
       </a>
       <NavBar />
-      <Routes>
-        <Route path='/' element={<Home />} />
-        <Route path='/aseo-general' element={<GeneralCleaning />} />
-        <Route path='/limpieza-herida' element={<WoundHealing />} />
-        <Route path='/realizar-dialisis' element={<WaterRecycling />} />
-        <Route path='*' element={<NoMatch />} />
-      </Routes>
+      <RouteList />
     </BrowserRouter>
   )
 }

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -38,7 +38,11 @@ export const GlobalStyle = createGlobalStyle`
     
     /* Dimensiones responsive */
     --header-height: clamp(60px, 15vw, 80px);
-    --footer-height: clamp(60px, 15vw, 80px);
+    /* Piso subido de 60px a 64px (PR5a): la barra de navegación ahora
+       muestra etiquetas de texto visibles bajo cada ícono (antes eran
+       sr-only), y necesita espacio vertical extra para 2 líneas de texto
+       sin recortar contenido — R4.2, R6.3. */
+    --footer-height: clamp(64px, 16vw, 84px);
     --border-radius: 0.5rem;
     --max-width-container: 1200px;
   }


### PR DESCRIPTION
Part of #3 (PR5a of the accessible-redesign chain — stacked on #8; retroactive size:exception accepted, reviewer confirmed no clean split)

## Summary

- NavBar: 4 group tabs (Inicio / Procedimientos / Cuidados / Comida y líquidos) with **visible labels** under icons (previously sr-only — low-literacy users navigate by icon + word), prefix-based active matching, 44px targets, no clipping at 360px
- Home becomes a hub with 3 grouped card sections so a first-time user can tell "how do I do my exchange" vs "what if something looks wrong" vs "what can I eat" without opening pages; daily schedules stay below
- 7 new routes scaffolded under Layout (`/procedimientos`, `/cuidados`, `/cuidados/higiene`, `/cuidados/senales-de-alarma`, `/alimentacion`, `/alimentacion/liquidos`, `/alimentacion/nutricion`) — topic pages are plain-language placeholders until PR6–9
- Legacy procedure URLs unchanged (byte-identical routes) — no bookmark breaks
- Pays down 5-PR-old debt: ProgressStep CompleteButton dark-mode contrast fixed (was 1.92:1), plus a newly-found `--color-success` hover failure (3.30:1) fixed alongside

## Contrast (independently recomputed by the review)

- CompleteButton: passes AA in both modes (verified exact)
- Active nav label (light): **4.76:1** against the composited active-tab tint — passes AA with a thinner margin than the initial 5.48:1 claim (reviewer-corrected figure)

## Test plan

- [x] `npm test`: 67/67 green (routing, active-state, and Home tests assert behavior, not render-only)
- [x] `npm run build` passes
- [x] Independent fresh-context review: PASS — 0 critical; caught and corrected the contrast documentation figure; verified legacy routes byte-identical

## Still open (tracked in #3)

- `--color-accent` (#3b82f6) white-text pairs in pre-existing components still fail AA (3.68:1) — flagged since PR1, candidate for a dedicated token pass