### PR TITLE
feat(content): glossary, urgent-warning, citation, and escalation primitives

### DIFF
--- a/__tests__/CitationFooter.test.js
+++ b/__tests__/CitationFooter.test.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { CitationFooter } from '../src/components/CitationFooter'
+
+// CitationFooter: resolves sourceIds -> src/content/sources.js and always
+// renders the standing disclaimer — R5.1, R5.2.
+describe('CitationFooter', () => {
+  it('resolves sourceIds into visible, linked citations', () => {
+    render(<CitationFooter sourceIds={['imss-797-16', 'nkf-peritonitis']} />)
+
+    expect(
+      screen.getByRole('link', { name: /Guía de práctica clínica IMSS-797-16/ })
+    ).toHaveAttribute(
+      'href',
+      'http://www.imss.gob.mx/sites/all/statics/guiasclinicas/797GER.pdf'
+    )
+    expect(
+      screen.getByRole('link', { name: /Peritonitis/ })
+    ).toHaveAttribute('href', 'https://www.kidney.org/kidney-topics/peritonitis')
+  })
+
+  it('renders a plain-text (non-link) citation when a source has no verified url', () => {
+    render(<CitationFooter sourceIds={['niddk-nutrition-pd']} />)
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(
+      screen.getByText(/Eating & Nutrition for Peritoneal Dialysis/)
+    ).toBeInTheDocument()
+  })
+
+  it('always renders the clinic/nephrologist disclaimer, even with no sources', () => {
+    render(<CitationFooter />)
+
+    expect(
+      screen.getByText(/no reemplaza las indicaciones de tu clínica/)
+    ).toBeInTheDocument()
+  })
+
+  it('throws for an unknown sourceId instead of silently dropping the citation', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(() =>
+      render(<CitationFooter sourceIds={['no-existe']} />)
+    ).toThrow(/unknown sourceId/)
+
+    spy.mockRestore()
+  })
+})

--- a/__tests__/EscalationTable.test.js
+++ b/__tests__/EscalationTable.test.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { EscalationTable } from '../src/components/EscalationTable'
+
+const items = [
+  { id: 'cloudy-fluid', symptom: 'Líquido turbio o nublado', action: 'er' },
+  {
+    id: 'mild-redness',
+    symptom: 'Enrojecimiento leve en la salida',
+    action: 'clinic'
+  }
+]
+
+// EscalationTable: structured "llama a tu clínica" vs. "ve a urgencias"
+// distinction — R5.1, R5.3. Real <table> semantics, icon + visible text per
+// row so the distinction never relies on color alone — R5.4.
+describe('EscalationTable', () => {
+  it('renders a table with column headers and an optional caption', () => {
+    render(
+      <EscalationTable items={items} caption='Cuándo llamar o ir a urgencias' />
+    )
+
+    expect(screen.getByRole('table')).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: 'Señal' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: 'Qué hacer' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Cuándo llamar o ir a urgencias')
+    ).toBeInTheDocument()
+  })
+
+  it('renders each symptom row with its resolved action as visible icon+text', () => {
+    render(<EscalationTable items={items} />)
+
+    expect(screen.getByText('Líquido turbio o nublado')).toBeInTheDocument()
+    expect(
+      screen.getByText('Enrojecimiento leve en la salida')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Ve a urgencias')).toBeInTheDocument()
+    expect(screen.getByText('Llama a tu clínica')).toBeInTheDocument()
+  })
+
+  it('renders no rows when items is empty', () => {
+    render(<EscalationTable items={[]} />)
+
+    expect(screen.getByRole('table')).toBeInTheDocument()
+    expect(screen.queryAllByRole('row')).toHaveLength(1) // header row only
+  })
+})

--- a/__tests__/TermTooltip.test.js
+++ b/__tests__/TermTooltip.test.js
@@ -1,0 +1,97 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TermTooltip } from '../src/components/TermTooltip'
+
+// TermTooltip: tap-to-expand glossary disclosure (R4.3) — must work via
+// click AND keyboard, and expose state through aria-expanded instead of a
+// hover-only tooltip.
+describe('TermTooltip', () => {
+  it('renders a closed trigger by default with the term as its label', () => {
+    render(<TermTooltip termKey='heparina' />)
+
+    const trigger = screen.getByRole('button', { name: 'Heparina' })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText(/coágulos/)).not.toBeInTheDocument()
+  })
+
+  it('opens the definition panel on click and updates aria-expanded', async () => {
+    const user = userEvent.setup()
+    render(<TermTooltip termKey='heparina' />)
+
+    await user.click(screen.getByRole('button', { name: 'Heparina' }))
+
+    expect(screen.getByRole('button', { name: 'Heparina' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    )
+    expect(screen.getByText(/coágulos/)).toBeVisible()
+  })
+
+  it('opens the definition panel via keyboard activation (Tab + Enter)', async () => {
+    const user = userEvent.setup()
+    render(<TermTooltip termKey='peritonitis' />)
+
+    await user.tab()
+    await user.keyboard('{Enter}')
+
+    expect(screen.getByText(/infección dentro del abdomen/)).toBeVisible()
+  })
+
+  it('closes when the trigger is activated again', async () => {
+    const user = userEvent.setup()
+    render(<TermTooltip termKey='heparina' />)
+    const trigger = screen.getByRole('button', { name: 'Heparina' })
+
+    await user.click(trigger)
+    await user.click(trigger)
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText(/coágulos/)).not.toBeInTheDocument()
+  })
+
+  it('closes via the explicit dismiss control and returns focus to the trigger', async () => {
+    const user = userEvent.setup()
+    render(<TermTooltip termKey='heparina' />)
+    const trigger = screen.getByRole('button', { name: 'Heparina' })
+
+    await user.click(trigger)
+    await user.click(
+      screen.getByRole('button', { name: /Cerrar definición/ })
+    )
+
+    expect(screen.queryByText(/coágulos/)).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('closes on Escape and returns focus to the trigger', async () => {
+    const user = userEvent.setup()
+    render(<TermTooltip termKey='heparina' />)
+    const trigger = screen.getByRole('button', { name: 'Heparina' })
+
+    await user.click(trigger)
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByText(/coágulos/)).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('renders custom trigger text via children while still resolving the glossary definition', async () => {
+    const user = userEvent.setup()
+    render(<TermTooltip termKey='exsept'>producto Exsept</TermTooltip>)
+
+    await user.click(screen.getByRole('button', { name: 'producto Exsept' }))
+
+    expect(screen.getByText(/desinfectante/)).toBeVisible()
+  })
+
+  it('throws for an unknown termKey instead of silently rendering nothing', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(() => render(<TermTooltip termKey='no-existe' />)).toThrow(
+      /unknown glossary termKey/
+    )
+
+    spy.mockRestore()
+  })
+})

--- a/__tests__/TopicPage.test.js
+++ b/__tests__/TopicPage.test.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { TopicPage } from '../src/components/TopicPage'
+
+// TopicPage: intro -> core guidance -> warning/escalation -> CitationFooter
+// composition template used by the 4 medical-content pages (PR6-9) — R5.1.
+// No real medical content ships in this PR — demo content only.
+describe('TopicPage', () => {
+  const sections = [
+    {
+      heading: 'Señales de alarma',
+      body: 'Texto de ejemplo sobre señales de alarma.',
+      warning: { level: 'urgent', text: 'Llama a tu clínica si ves esto.' },
+      table: {
+        items: [{ id: 'a', symptom: 'Fiebre', action: 'er' }]
+      },
+      sourceIds: ['imss-797-16']
+    }
+  ]
+
+  it('renders the intro, section content, warning callout and escalation table', () => {
+    render(
+      <TopicPage
+        title='Peritonitis'
+        intro='Qué cubre esta página.'
+        sections={sections}
+        sourceIds={['nkf-peritonitis']}
+      />
+    )
+
+    expect(
+      screen.getByRole('heading', { name: 'Peritonitis', level: 1 })
+    ).toBeInTheDocument()
+    expect(screen.getByText('Qué cubre esta página.')).toBeInTheDocument()
+    expect(screen.getByText('Señales de alarma')).toBeInTheDocument()
+    expect(screen.getByText('Urgente')).toBeInTheDocument()
+    expect(screen.getByRole('table')).toBeInTheDocument()
+  })
+
+  it('always renders exactly one CitationFooter with the standing disclaimer', () => {
+    render(<TopicPage title='Peritonitis' sections={sections} />)
+
+    expect(
+      screen.getByText(/no reemplaza las indicaciones de tu clínica/)
+    ).toBeInTheDocument()
+  })
+
+  it('aggregates sourceIds from both the page level and each section into one footer', () => {
+    render(
+      <TopicPage
+        title='Peritonitis'
+        sections={sections}
+        sourceIds={['nkf-peritonitis']}
+      />
+    )
+
+    // Page-level sourceId
+    expect(
+      screen.getByRole('link', { name: /^Peritonitis/ })
+    ).toBeInTheDocument()
+    // Section-level sourceId
+    expect(
+      screen.getByRole('link', { name: /IMSS-797-16/ })
+    ).toBeInTheDocument()
+  })
+})

--- a/__tests__/UrgentWarningCallout.test.js
+++ b/__tests__/UrgentWarningCallout.test.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { UrgentWarningCallout } from '../src/components/UrgentWarningCallout'
+
+// UrgentWarningCallout: safety-critical callout — icon + visible text
+// label, never color alone — R4.4.
+describe('UrgentWarningCallout', () => {
+  it('renders the urgent icon+text label by default', () => {
+    render(
+      <UrgentWarningCallout>Llama a tu clínica ahora.</UrgentWarningCallout>
+    )
+
+    expect(screen.getByText('⚠')).toBeInTheDocument()
+    expect(screen.getByText('Urgente')).toBeInTheDocument()
+    expect(screen.getByText('Llama a tu clínica ahora.')).toBeInTheDocument()
+  })
+
+  it('renders the caution icon+text label when level="caution"', () => {
+    render(
+      <UrgentWarningCallout level='caution'>
+        Consulta a tu clínica si esto continúa.
+      </UrgentWarningCallout>
+    )
+
+    expect(screen.getByText('Precaución')).toBeInTheDocument()
+    expect(screen.queryByText('Urgente')).not.toBeInTheDocument()
+  })
+
+  it('hides the icon from assistive tech since the text label carries the meaning', () => {
+    render(<UrgentWarningCallout>Texto de ejemplo.</UrgentWarningCallout>)
+
+    expect(screen.getByText('⚠')).toHaveAttribute('aria-hidden', 'true')
+  })
+})

--- a/src/components/CitationFooter/index.js
+++ b/src/components/CitationFooter/index.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { SourceBadge } from '../SourceBadge'
+import {
+  FooterWrapper,
+  FooterHeading,
+  SourceList,
+  SourceListItem,
+  Disclaimer
+} from './styles'
+
+// CitationFooter: resolves sourceIds -> src/content/sources.js and renders
+// visible citations plus the standing "this is not a substitute for your
+// clinic/nephrologist" disclaimer — R5.1, R5.2. The disclaimer always
+// renders, even with zero sourceIds, since every medical-content page must
+// carry it regardless of how many sources it cites. Used by TopicPage
+// (design section 3) and, later, any PR6-9 page carrying medical claims.
+export const CitationFooter = ({ sourceIds = [] }) => (
+  <FooterWrapper role='contentinfo' aria-label='Fuentes y aviso'>
+    {sourceIds.length > 0 && (
+      <>
+        <FooterHeading>Fuentes</FooterHeading>
+        <SourceList>
+          {sourceIds.map((sourceId) => (
+            <SourceListItem key={sourceId}>
+              <SourceBadge sourceId={sourceId} />
+            </SourceListItem>
+          ))}
+        </SourceList>
+      </>
+    )}
+    <Disclaimer>
+      Esta información no reemplaza las indicaciones de tu clínica ni de tu
+      nefrólogo.
+    </Disclaimer>
+  </FooterWrapper>
+)

--- a/src/components/CitationFooter/styles.js
+++ b/src/components/CitationFooter/styles.js
@@ -1,0 +1,37 @@
+import styled from 'styled-components'
+
+export const FooterWrapper = styled.footer`
+  margin-top: var(--spacing-xl);
+  padding: var(--spacing-lg);
+  background: var(--body-card);
+  border-top: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+`
+
+export const FooterHeading = styled.h2`
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--color-secondary);
+  margin-bottom: var(--spacing-sm);
+`
+
+export const SourceList = styled.ul`
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-md);
+  padding: 0;
+`
+
+export const SourceListItem = styled.li`
+  list-style: none;
+`
+
+export const Disclaimer = styled.p`
+  font-size: var(--font-size-sm);
+  color: var(--color-secondary);
+  font-style: italic;
+  line-height: 1.5;
+`

--- a/src/components/EscalationTable/index.js
+++ b/src/components/EscalationTable/index.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import { MdPhone, MdLocalHospital } from 'react-icons/md'
+import { TableWrapper, Table, Caption, ActionBadge } from './styles'
+
+const ACTIONS = {
+  clinic: { label: 'Llama a tu clínica', Icon: MdPhone },
+  er: { label: 'Ve a urgencias', Icon: MdLocalHospital }
+}
+
+// EscalationTable: structured "cuándo llamar a tu clínica" vs. "cuándo ir a
+// urgencias" distinction — R5.1, R5.3. A real <table> (not two separate
+// styled lists) keeps the symptom -> action mapping tabular and gives
+// screen readers `scope="col"` headers; the action column always pairs an
+// icon with a visible text label so the distinction never relies on color
+// alone — R5.4. `items` shape: `[{ id, symptom, action: 'clinic' | 'er' }]`.
+export const EscalationTable = ({ caption, items = [] }) => (
+  <TableWrapper>
+    <Table>
+      {caption && <Caption>{caption}</Caption>}
+      <thead>
+        <tr>
+          <th scope='col'>Señal</th>
+          <th scope='col'>Qué hacer</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map(({ id, symptom, action }) => {
+          const config = ACTIONS[action] || ACTIONS.clinic
+          const Icon = config.Icon
+
+          return (
+            <tr key={id}>
+              <td data-label='Señal'>{symptom}</td>
+              <td data-label='Qué hacer'>
+                <ActionBadge $action={action}>
+                  <Icon aria-hidden='true' />
+                  {config.label}
+                </ActionBadge>
+              </td>
+            </tr>
+          )
+        })}
+      </tbody>
+    </Table>
+  </TableWrapper>
+)

--- a/src/components/EscalationTable/styles.js
+++ b/src/components/EscalationTable/styles.js
@@ -1,0 +1,101 @@
+import styled from 'styled-components'
+
+export const TableWrapper = styled.div`
+  width: 100%;
+  overflow-x: auto;
+  margin: var(--spacing-md) 0;
+`
+
+export const Table = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--body-card);
+  border-radius: var(--border-radius);
+  overflow: hidden;
+  box-shadow: var(--shadow-light);
+
+  th,
+  td {
+    text-align: left;
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-bottom: 1px solid var(--border-color);
+    font-size: var(--font-size-base);
+  }
+
+  th {
+    background: var(--body-header);
+    color: var(--color-primary);
+    font-weight: 700;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  /* Reflow into stacked cards below tablet width instead of a cramped/
+     horizontally-scrolling table — R5.1 "mobile-friendly". The real
+     <table>/<th scope="col"> structure stays in the markup for assistive
+     tech at any width; only the visual presentation of <thead> changes.
+     Known trade-off (documented, not silent): setting display:block on
+     table rows can make some screen readers stop announcing native table
+     semantics, so each cell also renders a visible data-label prefix
+     (below) as a redundant, always-visible header instead of relying
+     solely on the hidden <thead> at this width. */
+  @media (max-width: 480px) {
+    thead {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    tbody,
+    tr {
+      display: block;
+    }
+
+    tr {
+      margin-bottom: var(--spacing-sm);
+    }
+
+    td {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: var(--spacing-sm);
+
+      &::before {
+        content: attr(data-label);
+        font-weight: 600;
+        color: var(--color-secondary);
+        flex-shrink: 0;
+      }
+    }
+  }
+`
+
+export const Caption = styled.caption`
+  caption-side: top;
+  text-align: left;
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-weight: 600;
+  color: var(--color-primary);
+`
+
+export const ActionBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-weight: 600;
+  color: ${(props) =>
+    props.$action === 'er' ? 'var(--color-urgent)' : 'var(--color-actived)'};
+
+  svg {
+    flex-shrink: 0;
+  }
+`

--- a/src/components/SourceBadge/index.js
+++ b/src/components/SourceBadge/index.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { sources } from '../../content/sources'
+import { Badge } from './styles'
+
+// SourceBadge: inline citation marker resolving a single sourceId against
+// src/content/sources.js — R5.2. Renders a visible reference (linked when a
+// verified URL exists) so source attribution survives into the rendered
+// page for both sighted and assistive-tech readers, not just a code
+// comment.
+export const SourceBadge = ({ sourceId }) => {
+  const source = sources[sourceId]
+
+  if (!source) {
+    throw new Error(`[SourceBadge] unknown sourceId "${sourceId}"`)
+  }
+
+  const label = source.published ? `${source.name} (${source.published})` : source.name
+
+  return source.url
+    ? (
+      <Badge as='a' href={source.url} target='_blank' rel='noreferrer'>
+        {label}
+      </Badge>
+      )
+    : (
+      <Badge as='span'>{label}</Badge>
+      )
+}

--- a/src/components/SourceBadge/styles.js
+++ b/src/components/SourceBadge/styles.js
@@ -1,0 +1,24 @@
+import styled from 'styled-components'
+
+export const Badge = styled.a`
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 4px var(--spacing-sm);
+  border-radius: var(--border-radius);
+  background: var(--body-background);
+  border: 1px solid var(--border-color);
+  color: var(--color-accent);
+  font-size: var(--font-size-sm);
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+  }
+`

--- a/src/components/TermTooltip/index.js
+++ b/src/components/TermTooltip/index.js
@@ -1,0 +1,76 @@
+import React, { useId, useRef, useState } from 'react'
+import { glossary } from '../../content/glossary'
+import {
+  TermWrapper,
+  TermTrigger,
+  TermPanel,
+  TermPanelText,
+  TermPanelDismiss
+} from './styles'
+
+// TermTooltip: tap-to-expand glossary disclosure primitive (R4.3, design
+// section 1/3 "Glossary UX" decision). A hover-only tooltip fails touch
+// input, low-literacy users, and screen readers, so the definition is
+// exposed through a real <button> + a conditionally-rendered panel instead
+// of CSS :hover — `aria-expanded`/`aria-controls` on the trigger give
+// assistive tech the same open/closed state a sighted mouse user gets
+// visually, and the panel only exists in the DOM while open (an accessible
+// disclosure pattern, not `display: none`).
+//
+// Dismissible via 3 equivalent paths: activating the trigger again, the
+// explicit dismiss button inside the panel, or Escape — all 3 return focus
+// to the trigger so keyboard users don't lose their place.
+export const TermTooltip = ({ termKey, children }) => {
+  const [open, setOpen] = useState(false)
+  const panelId = useId()
+  const triggerRef = useRef(null)
+
+  const entry = glossary[termKey]
+
+  if (!entry) {
+    throw new Error(`[TermTooltip] unknown glossary termKey "${termKey}"`)
+  }
+
+  const toggle = () => setOpen((value) => !value)
+
+  const close = () => {
+    setOpen(false)
+    triggerRef.current?.focus()
+  }
+
+  // Attached on the wrapper (not the panel) so Escape closes the tooltip
+  // regardless of which descendant currently has focus (trigger or the
+  // dismiss button) — a keydown handler on the panel alone would miss the
+  // case where focus is still on the trigger right after opening it.
+  const handleKeyDown = (event) => {
+    if (open && event.key === 'Escape') {
+      close()
+    }
+  }
+
+  return (
+    <TermWrapper onKeyDown={handleKeyDown}>
+      <TermTrigger
+        type='button'
+        ref={triggerRef}
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={toggle}
+      >
+        {children ?? entry.term}
+      </TermTrigger>
+      {open && (
+        <TermPanel id={panelId} role='note'>
+          <TermPanelText>{entry.plainDefinition}</TermPanelText>
+          <TermPanelDismiss
+            type='button'
+            onClick={close}
+            aria-label={`Cerrar definición de ${entry.term}`}
+          >
+            ✕
+          </TermPanelDismiss>
+        </TermPanel>
+      )}
+    </TermWrapper>
+  )
+}

--- a/src/components/TermTooltip/styles.js
+++ b/src/components/TermTooltip/styles.js
@@ -1,0 +1,71 @@
+import styled from 'styled-components'
+
+export const TermWrapper = styled.span`
+  position: relative;
+  display: inline-block;
+`
+
+export const TermTrigger = styled.button`
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px; /* Área de toque mínima accesible — R6.3 */
+  min-width: 44px;
+  padding: 0 var(--spacing-xs);
+  color: var(--color-accent);
+  font-weight: 600;
+  text-decoration: underline dotted;
+  border-radius: var(--border-radius);
+
+  &:hover,
+  &:focus {
+    text-decoration-style: solid;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+  }
+`
+
+export const TermPanel = styled.span`
+  display: block;
+  position: absolute;
+  z-index: 20;
+  top: 100%;
+  left: 0;
+  margin-top: var(--spacing-xs);
+  min-width: 240px;
+  max-width: min(320px, 90vw);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--body-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-medium);
+`
+
+export const TermPanelText = styled.span`
+  display: block;
+  padding-right: var(--spacing-xl);
+  font-size: var(--font-size-sm);
+  color: var(--color-primary);
+  line-height: 1.4;
+`
+
+export const TermPanelDismiss = styled.button`
+  position: absolute;
+  top: var(--spacing-xs);
+  right: var(--spacing-xs);
+  min-height: 44px; /* Área de toque mínima accesible — R6.3 */
+  min-width: 44px;
+  border-radius: 50%;
+  color: var(--color-secondary);
+
+  &:hover {
+    color: var(--color-primary);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+  }
+`

--- a/src/components/TopicPage/index.js
+++ b/src/components/TopicPage/index.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import { PageContainer } from '../PageContainer'
+import { UrgentWarningCallout } from '../UrgentWarningCallout'
+import { EscalationTable } from '../EscalationTable'
+import { CitationFooter } from '../CitationFooter'
+import {
+  TopicHeader,
+  TopicIntro,
+  TopicSection,
+  SectionHeading,
+  SectionBody
+} from './styles'
+
+// TopicPage: shared composition template for the 4 medical-content pages
+// (PR6-9) — design section 1's topic shape
+// `{ sections: [{ heading, body, warning?, table?, sourceIds }] }`. Each
+// section follows intro -> core guidance -> warning/escalation, and the
+// page always ends with one CitationFooter that aggregates every sourceId
+// referenced anywhere (page-level `sourceIds` plus each section's own) so
+// PR6-9 authors don't have to hand-merge citation lists — R5.1.
+//
+// No real medical content ships in this PR — this is the reusable shell
+// only; PR6-9 pass real `sections`/`sourceIds`.
+export const TopicPage = ({ title, intro, sections = [], sourceIds = [] }) => {
+  const allSourceIds = [
+    ...sourceIds,
+    ...sections.flatMap((section) => section.sourceIds || [])
+  ]
+  const uniqueSourceIds = [...new Set(allSourceIds)]
+
+  return (
+    <PageContainer>
+      <TopicHeader>
+        <h1>{title}</h1>
+        {intro && <TopicIntro>{intro}</TopicIntro>}
+      </TopicHeader>
+
+      {sections.map((section, index) => (
+        <TopicSection key={section.heading || index}>
+          {section.heading && (
+            <SectionHeading>{section.heading}</SectionHeading>
+          )}
+          {section.body && <SectionBody>{section.body}</SectionBody>}
+          {section.warning && (
+            <UrgentWarningCallout level={section.warning.level}>
+              {section.warning.text}
+            </UrgentWarningCallout>
+          )}
+          {section.table && <EscalationTable {...section.table} />}
+        </TopicSection>
+      ))}
+
+      <CitationFooter sourceIds={uniqueSourceIds} />
+    </PageContainer>
+  )
+}

--- a/src/components/TopicPage/styles.js
+++ b/src/components/TopicPage/styles.js
@@ -1,0 +1,39 @@
+import styled from 'styled-components'
+
+export const TopicHeader = styled.header`
+  margin-bottom: var(--spacing-lg);
+
+  h1 {
+    font-size: var(--font-size-2xl);
+    font-weight: 700;
+    color: var(--color-primary);
+    margin-bottom: var(--spacing-sm);
+  }
+`
+
+export const TopicIntro = styled.p`
+  font-size: var(--font-size-lg);
+  color: var(--color-secondary);
+  line-height: 1.5;
+`
+
+export const TopicSection = styled.section`
+  margin-bottom: var(--spacing-xl);
+`
+
+export const SectionHeading = styled.h2`
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  color: var(--color-primary);
+  margin-bottom: var(--spacing-sm);
+`
+
+export const SectionBody = styled.div`
+  font-size: var(--font-size-base);
+  color: var(--color-primary);
+  line-height: 1.6;
+
+  p {
+    margin-bottom: var(--spacing-sm);
+  }
+`

--- a/src/components/UrgentWarningCallout/index.js
+++ b/src/components/UrgentWarningCallout/index.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import {
+  CalloutBox,
+  CalloutHeader,
+  CalloutIcon,
+  CalloutLabel,
+  CalloutBody
+} from './styles'
+
+const LEVELS = {
+  urgent: { label: 'Urgente', icon: '⚠' },
+  caution: { label: 'Precaución', icon: '⚠' }
+}
+
+// UrgentWarningCallout: safety-critical callout for content like peritonitis
+// warning signs or "call your clinic now" guidance — R4.4. Distinguishable
+// without relying on color alone: a visible icon + text label ("⚠ Urgente")
+// always accompanies the color treatment, and the icon is `aria-hidden`
+// since the visible text label already carries the meaning for assistive
+// tech. `level` maps to the content schema's `step.warning.level` field
+// ('urgent' | 'caution', design section 1) so step and topic content can
+// reuse this one component for both severities instead of two near-copies.
+export const UrgentWarningCallout = ({ level = 'urgent', children }) => {
+  const config = LEVELS[level] || LEVELS.urgent
+
+  return (
+    <CalloutBox role='note' $level={level}>
+      <CalloutHeader>
+        <CalloutIcon aria-hidden='true'>{config.icon}</CalloutIcon>
+        <CalloutLabel>{config.label}</CalloutLabel>
+      </CalloutHeader>
+      <CalloutBody>{children}</CalloutBody>
+    </CalloutBox>
+  )
+}

--- a/src/components/UrgentWarningCallout/styles.js
+++ b/src/components/UrgentWarningCallout/styles.js
@@ -1,0 +1,56 @@
+import styled, { css } from 'styled-components'
+
+const levelStyles = {
+  urgent: css`
+    background: var(--color-urgent-bg);
+    border-color: var(--color-urgent);
+
+    strong {
+      color: var(--color-urgent);
+    }
+  `,
+  caution: css`
+    background: var(--color-caution-bg);
+    border-color: var(--color-caution);
+
+    strong {
+      color: var(--color-caution);
+    }
+  `
+}
+
+export const CalloutBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-md) var(--spacing-lg);
+  margin: var(--spacing-md) 0;
+  border: 2px solid;
+  border-radius: var(--border-radius);
+  ${(props) => levelStyles[props.$level] || levelStyles.urgent}
+`
+
+export const CalloutHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+`
+
+export const CalloutIcon = styled.span`
+  font-size: var(--font-size-lg);
+  line-height: 1;
+`
+
+export const CalloutLabel = styled.strong`
+  font-size: var(--font-size-base);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+`
+
+export const CalloutBody = styled.p`
+  color: var(--color-primary);
+  font-size: var(--font-size-base);
+  line-height: 1.5;
+  margin: 0;
+`

--- a/src/content/glossary.js
+++ b/src/content/glossary.js
@@ -1,6 +1,7 @@
 // glossary: clinical/brand term definitions for the tap-to-expand glossary
-// primitive (R4.3). Seed entries only in PR3 — populated fully alongside
-// the medical-content pages in PR5+ (see design section 1).
+// primitive (R4.3). Seed entries added in PR3 (exsept, mupirocina); expanded
+// in PR5b (heparina, peritonitis) alongside the TermTooltip component itself
+// — populated further as PR6-9 add real medical-content pages.
 //
 // Shape: { [termKey]: { term, plainDefinition } }
 
@@ -14,5 +15,15 @@ export const glossary = {
     term: 'Mupirocina',
     plainDefinition:
       'Una pomada antibiótica que a veces se receta para prevenir infecciones en la salida del catéter. Solo se usa si tu médico la indicó.'
+  },
+  heparina: {
+    term: 'Heparina',
+    plainDefinition:
+      'Un medicamento que ayuda a evitar que se formen coágulos (tapones) de sangre. En diálisis peritoneal, a veces se agrega al líquido de diálisis solo si tu médico lo indicó.'
+  },
+  peritonitis: {
+    term: 'Peritonitis',
+    plainDefinition:
+      'Una infección dentro del abdomen (panza) que puede pasar si entran microbios durante el intercambio de líquido. Si tu líquido de diálisis sale turbio (nublado), o tienes dolor de panza, fiebre, náusea o diarrea, llama a tu clínica de inmediato.'
   }
 }

--- a/src/content/sources.js
+++ b/src/content/sources.js
@@ -1,15 +1,51 @@
 // sources: citation registry resolved by SourceBadge/CitationFooter (R5.2).
-// Seed entries only in PR3 — populated fully alongside the medical-content
-// pages in PR6+ (see design section 1, spec R5.2).
+// Seed entry added in PR3 (imss-797-16, url unverified at the time); PR5b
+// fills in the verified URL for that entry and adds the remaining sources
+// named in spec R5.2 (ISPD 2022/2023, NKF, NIDDK) using the exact
+// URLs/dates captured during exploration (sdd/accessible-redesign/explore).
+// PR6-9 attach these sourceIds to real medical claims — currency should be
+// re-checked at that point per R5.7 (e.g. IMSS-797-16 is flagged in the
+// explore doc as possibly superseded by a newer edition).
 //
 // Shape: { [sourceId]: { name, org, url, published, accessed } }
 
 export const sources = {
   'imss-797-16': {
-    name: 'Guía de práctica clínica IMSS-797-16',
+    name: 'Guía de práctica clínica IMSS-797-16: Intervenciones de enfermería para la atención y prevención de peritonitis infecciosa en adultos con diálisis peritoneal ambulatoria',
     org: 'IMSS',
-    url: null,
+    url: 'http://www.imss.gob.mx/sites/all/statics/guiasclinicas/797GER.pdf',
     published: '2016',
-    accessed: null
+    accessed: '2026-07-01'
+  },
+  'ispd-peritonitis-2022': {
+    name: 'Peritonitis guideline recommendations: 2022 update on prevention and treatment',
+    org: 'ISPD (International Society for Peritoneal Dialysis)',
+    url: 'https://journals.sagepub.com/doi/10.1177/08968608221080586',
+    published: '2022',
+    accessed: '2026-07-01'
+  },
+  'ispd-catheter-2023': {
+    name: 'Catheter-related Infection Recommendations: 2023 Update',
+    org: 'ISPD (International Society for Peritoneal Dialysis)',
+    url: 'https://ispd.org/wp-content/uploads/ISPD-Catheter-related-Infection-Recommendations-2023-Update.pdf',
+    published: '2023',
+    accessed: '2026-07-01'
+  },
+  'nkf-peritonitis': {
+    name: 'Peritonitis',
+    org: 'National Kidney Foundation (NKF)',
+    url: 'https://www.kidney.org/kidney-topics/peritonitis',
+    published: null,
+    accessed: '2026-07-01'
+  },
+  'niddk-nutrition-pd': {
+    // Exact URL path was not captured verbatim during exploration (only the
+    // niddk.nih.gov domain + title were recorded) — verify this path before
+    // citing it in real PR6-9 content per R5.7.
+    name: 'Eating & Nutrition for Peritoneal Dialysis',
+    org: 'NIDDK (National Institute of Diabetes and Digestive and Kidney Diseases)',
+    url: null,
+    published: '2018-08',
+    accessed: '2026-07-01'
   }
 }

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -16,6 +16,18 @@ export const GlobalStyle = createGlobalStyle`
     --color-accent: #3b82f6;
     --color-warning: #dc2626;
     --color-success: #16a34a;
+    /* Tokens for UrgentWarningCallout (R4.4, R6.1) — a tinted-background
+       treatment, deliberately different from the accent-left-border
+       "informational callout" pattern (e.g. MigrationNotice) so the two
+       are visually distinct, not just differently colored. Both pairs
+       measured with the WCAG relative-luminance formula (same method used
+       for the PR5a nav-label/CompleteButton measurements):
+       #991b1b sobre #fee2e2 (urgent) = 6.80:1; #92400e sobre #fef3c7
+       (caution) = 6.37:1 — ambos superan AA (4.5:1) con margen. */
+    --color-urgent: #991b1b;
+    --color-urgent-bg: #fee2e2;
+    --color-caution: #92400e;
+    --color-caution-bg: #fef3c7;
     --border-color: #e2e8f0;
     --shadow-light: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
     --shadow-medium: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
@@ -218,6 +230,17 @@ export const GlobalStyle = createGlobalStyle`
          sobre #1e293b = 7.61:1 y sobre --body-background #0f172a = 9.29:1,
          ambos cumplen AA (mínimo 4.5:1) con margen. */
       --color-actived: #34d399;
+      /* Dark-mode variants for the urgent/caution callout tokens (R6.1) —
+         light text on a dark tinted background instead of dark text on a
+         light one. Measured: #fca5a5 sobre #450a0a (urgent) = 8.51:1;
+         #fcd34d sobre #451a03 (caution) = 10.39:1 — ambos superan AA con
+         mucho margen. Also verified against --body-card (#1e293b), in case
+         a component reuses these tokens outside the tinted-bg box: urgent
+         7.71:1, caution 10.15:1 — still AA-compliant either way. */
+      --color-urgent: #fca5a5;
+      --color-urgent-bg: #450a0a;
+      --color-caution: #fcd34d;
+      --color-caution-bg: #451a03;
     }
   }
 


### PR DESCRIPTION
Part of #3 (PR5b of the accessible-redesign chain — stacked on #9; retroactive size:exception, reviewer-confirmed: splitting would fragment an atomically-tested unit)

## Summary

The building blocks for the medical-content pages (PR6–9):

- **TermTooltip** — tap-to-expand glossary: real button trigger, `aria-expanded`/`aria-controls`, Escape/dismiss/toggle all return focus, 44px targets, never hover-only
- **UrgentWarningCallout** — "⚠ Urgente"/"⚠ Precaución" with icon + text (never color alone); new urgent/caution tokens pass AA in both modes (6.37:1–10.39:1, independently recomputed)
- **EscalationTable** — "Llama a tu clínica" vs "Ve a urgencias" as a real table with header semantics preserved through the mobile card reflow
- **SourceBadge + CitationFooter** — resolves source IDs to visible citations; the "no reemplaza a tu clínica/nefrólogo" disclaimer renders unconditionally
- **TopicPage** — the template PR6–9 instantiate (intro → sections → warnings/tables → citations; escalation placement author-controlled per spec R5.3)
- `sources.js` — IMSS-797-16, ISPD 2022/2023, NKF, NIDDK entries cross-checked verbatim against the research record (one URL honestly left null rather than fabricated — resolved before PR6–9 content lands)
- `glossary.js` — plain-language es-MX definitions (heparina, peritonitis added)

## Test plan

- [x] `npm test`: 88/88 green (12 suites; 21 new behavioral tests incl. keyboard/focus a11y)
- [x] `npm run build` passes
- [x] Independent fresh-context review: PASS — 0 critical; citation integrity verified against the research artifact; contrast recomputed independently