### PR TITLE
feat(content): hygiene deep-dive page — wound care, clean environment, safe food prep

### DIFF
--- a/__tests__/CitationFooter.test.js
+++ b/__tests__/CitationFooter.test.js
@@ -2,6 +2,28 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { CitationFooter } from '../src/components/CitationFooter'
 
+// PR6 filled in niddk-nutrition-pd's real URL (was the null-url fixture
+// used below), so every real source now has a verified URL. The
+// plain-text/no-verified-url branch is still real production logic
+// (SourceBadge falls back to a <span> whenever a source's url is null), so
+// this fixture keeps that branch covered without depending on production
+// data always containing an unverified entry.
+jest.mock('../src/content/sources', () => {
+  const actual = jest.requireActual('../src/content/sources')
+  return {
+    sources: {
+      ...actual.sources,
+      'no-url-fixture': {
+        name: 'Fuente sin URL verificada',
+        org: 'Test',
+        url: null,
+        published: null,
+        accessed: '2026-07-02'
+      }
+    }
+  }
+})
+
 // CitationFooter: resolves sourceIds -> src/content/sources.js and always
 // renders the standing disclaimer — R5.1, R5.2.
 describe('CitationFooter', () => {
@@ -20,12 +42,10 @@ describe('CitationFooter', () => {
   })
 
   it('renders a plain-text (non-link) citation when a source has no verified url', () => {
-    render(<CitationFooter sourceIds={['niddk-nutrition-pd']} />)
+    render(<CitationFooter sourceIds={['no-url-fixture']} />)
 
     expect(screen.queryByRole('link')).not.toBeInTheDocument()
-    expect(
-      screen.getByText(/Eating & Nutrition for Peritoneal Dialysis/)
-    ).toBeInTheDocument()
+    expect(screen.getByText(/Fuente sin URL verificada/)).toBeInTheDocument()
   })
 
   it('always renders the clinic/nephrologist disclaimer, even with no sources', () => {

--- a/__tests__/CitationFooter.test.js
+++ b/__tests__/CitationFooter.test.js
@@ -34,7 +34,7 @@ describe('CitationFooter', () => {
       screen.getByRole('link', { name: /Guía de práctica clínica IMSS-797-16/ })
     ).toHaveAttribute(
       'href',
-      'http://www.imss.gob.mx/sites/all/statics/guiasclinicas/797GER.pdf'
+      'http://www.imss.gob.mx/sites/all/statics/guiasclinicas/797GRR.pdf'
     )
     expect(
       screen.getByRole('link', { name: /Peritonitis/ })

--- a/__tests__/Higiene.test.js
+++ b/__tests__/Higiene.test.js
@@ -1,0 +1,110 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { RouteList } from '../src/routes/RouteList'
+
+const renderHigiene = () =>
+  render(
+    <MemoryRouter initialEntries={['/cuidados/higiene']}>
+      <RouteList />
+    </MemoryRouter>
+  )
+
+// Higiene: real content page at /cuidados/higiene (PR6) — R5.1, R5.7.
+describe('Higiene page', () => {
+  it('renders under Layout at its route with the page title', () => {
+    renderHigiene()
+
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Higiene', level: 1 })
+    ).toBeInTheDocument()
+  })
+
+  it('places the exit-site infection warning high on the page', () => {
+    renderHigiene()
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Señales de infección en el sitio de salida'
+      })
+    ).toBeInTheDocument()
+    expect(screen.getByText('Urgente')).toBeInTheDocument()
+    expect(
+      screen.getByText(/enrojecimiento, hinchazón, dolor, calor o pus/)
+    ).toBeInTheDocument()
+  })
+
+  it('renders every core guidance section', () => {
+    renderHigiene()
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Lávate las manos antes de cada intercambio'
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Cuida el sitio de salida y el catéter' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', {
+        name: 'Mantén limpio tu espacio de intercambio'
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Prepara tus alimentos con higiene' })
+    ).toBeInTheDocument()
+  })
+
+  it('states the source-verified numbers only (70% alcohol gel, ~2 week healing)', () => {
+    renderHigiene()
+
+    expect(screen.getByText(/al 70%/)).toBeInTheDocument()
+    expect(screen.getByText(/alrededor de 2 semanas/)).toBeInTheDocument()
+  })
+
+  it('renders the WHO five keys to safer food', () => {
+    renderHigiene()
+
+    expect(screen.getByText('Mantén la limpieza.')).toBeInTheDocument()
+    expect(
+      screen.getByText('Separa los alimentos crudos de los cocinados.')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Cocina completamente los alimentos.')).toBeInTheDocument()
+    expect(
+      screen.getByText('Mantén los alimentos a temperaturas seguras.')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Usa agua y materias primas seguras.')).toBeInTheDocument()
+  })
+
+  it('resolves citations and always shows the clinic/nephrologist disclaimer', () => {
+    renderHigiene()
+
+    expect(
+      screen.getByRole('link', { name: /Guía de práctica clínica IMSS-797-16/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /Diálisis - peritoneal/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', {
+        name: /Manual sobre las cinco claves para la inocuidad de los alimentos/
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/no reemplaza las indicaciones de tu clínica/)
+    ).toBeInTheDocument()
+  })
+
+  it('glossary-links peritonitis, sitio de salida and catéter on first use', () => {
+    renderHigiene()
+
+    expect(
+      screen.getByRole('button', { name: 'peritonitis' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'sitio de salida' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'catéter' })).toBeInTheDocument()
+  })
+})

--- a/__tests__/Higiene.test.js
+++ b/__tests__/Higiene.test.js
@@ -96,7 +96,7 @@ describe('Higiene page', () => {
     ).toBeInTheDocument()
   })
 
-  it('glossary-links peritonitis, sitio de salida and catéter on first use', () => {
+  it('glossary-links peritonitis, sitio de salida, catéter and clorhexidina on first use', () => {
     renderHigiene()
 
     expect(
@@ -106,5 +106,8 @@ describe('Higiene page', () => {
       screen.getByRole('button', { name: 'sitio de salida' })
     ).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'catéter' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'clorhexidina' })
+    ).toBeInTheDocument()
   })
 })

--- a/__tests__/RouteList.test.js
+++ b/__tests__/RouteList.test.js
@@ -41,7 +41,6 @@ describe('RouteList', () => {
   })
 
   it.each([
-    '/cuidados/higiene',
     '/cuidados/senales-de-alarma',
     '/alimentacion/liquidos',
     '/alimentacion/nutricion'
@@ -49,6 +48,15 @@ describe('RouteList', () => {
     renderAt(path)
     expect(screen.getByRole('main')).toBeInTheDocument()
     expect(screen.getByText(/preparando esta guía/)).toBeInTheDocument()
+  })
+
+  it('renders the real Higiene content page at /cuidados/higiene under Layout', () => {
+    renderAt('/cuidados/higiene')
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Higiene', level: 1 })
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/preparando esta guía/)).not.toBeInTheDocument()
   })
 
   it('falls back to NoMatch on an unknown route', () => {

--- a/__tests__/TopicPage.test.js
+++ b/__tests__/TopicPage.test.js
@@ -29,7 +29,7 @@ describe('TopicPage', () => {
     )
 
     expect(
-      screen.getByRole('heading', { name: 'Peritonitis', level: 1 })
+      screen.getByRole('heading', { name: 'Peritonitis', level: 2 })
     ).toBeInTheDocument()
     expect(screen.getByText('Qué cubre esta página.')).toBeInTheDocument()
     expect(screen.getByText('Señales de alarma')).toBeInTheDocument()

--- a/src/components/TopicPage/index.js
+++ b/src/components/TopicPage/index.js
@@ -21,6 +21,13 @@ import {
 //
 // No real medical content ships in this PR — this is the reusable shell
 // only; PR6-9 pass real `sections`/`sourceIds`.
+//
+// Heading levels: the page's own <h1> always belongs to Layout (every page
+// in this app follows that convention — see CuidadosIndex, ProcedimientosIndex,
+// TopicComingSoon, ProgressStep's StepTitle). TopicPage is always composed
+// inside Layout, so `title` renders as <h2> here (not <h1>, fixed in PR6 —
+// the PR5b version rendered <h1>, which produced two identical <h1>s once a
+// real page wrapped it in Layout) and each section heading renders as <h3>.
 export const TopicPage = ({ title, intro, sections = [], sourceIds = [] }) => {
   const allSourceIds = [
     ...sourceIds,
@@ -31,7 +38,7 @@ export const TopicPage = ({ title, intro, sections = [], sourceIds = [] }) => {
   return (
     <PageContainer>
       <TopicHeader>
-        <h1>{title}</h1>
+        <h2>{title}</h2>
         {intro && <TopicIntro>{intro}</TopicIntro>}
       </TopicHeader>
 

--- a/src/components/TopicPage/styles.js
+++ b/src/components/TopicPage/styles.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 export const TopicHeader = styled.header`
   margin-bottom: var(--spacing-lg);
 
-  h1 {
+  h2 {
     font-size: var(--font-size-2xl);
     font-weight: 700;
     color: var(--color-primary);
@@ -21,7 +21,7 @@ export const TopicSection = styled.section`
   margin-bottom: var(--spacing-xl);
 `
 
-export const SectionHeading = styled.h2`
+export const SectionHeading = styled.h3`
   font-size: var(--font-size-xl);
   font-weight: 700;
   color: var(--color-primary);

--- a/src/content/glossary.js
+++ b/src/content/glossary.js
@@ -1,7 +1,8 @@
 // glossary: clinical/brand term definitions for the tap-to-expand glossary
 // primitive (R4.3). Seed entries added in PR3 (exsept, mupirocina); expanded
-// in PR5b (heparina, peritonitis) alongside the TermTooltip component itself
-// — populated further as PR6-9 add real medical-content pages.
+// in PR5b (heparina, peritonitis) alongside the TermTooltip component itself.
+// PR6 adds sitioSalida/cateter for the hygiene deep-dive page — populated
+// further as PR7-9 add their own real medical-content pages.
 //
 // Shape: { [termKey]: { term, plainDefinition } }
 
@@ -25,5 +26,15 @@ export const glossary = {
     term: 'Peritonitis',
     plainDefinition:
       'Una infección dentro del abdomen (panza) que puede pasar si entran microbios durante el intercambio de líquido. Si tu líquido de diálisis sale turbio (nublado), o tienes dolor de panza, fiebre, náusea o diarrea, llama a tu clínica de inmediato.'
+  },
+  sitioSalida: {
+    term: 'Sitio de salida',
+    plainDefinition:
+      'El lugar de tu piel por donde sale el catéter de tu cuerpo. Necesita limpieza diaria para prevenir infecciones.'
+  },
+  cateter: {
+    term: 'Catéter',
+    plainDefinition:
+      'Un tubo suave que tu médico coloca en tu abdomen, casi siempre cerca del ombligo. Por él entra y sale el líquido de diálisis.'
   }
 }

--- a/src/content/glossary.js
+++ b/src/content/glossary.js
@@ -1,8 +1,8 @@
 // glossary: clinical/brand term definitions for the tap-to-expand glossary
 // primitive (R4.3). Seed entries added in PR3 (exsept, mupirocina); expanded
 // in PR5b (heparina, peritonitis) alongside the TermTooltip component itself.
-// PR6 adds sitioSalida/cateter for the hygiene deep-dive page — populated
-// further as PR7-9 add their own real medical-content pages.
+// PR6 adds sitioSalida/cateter/clorhexidina for the hygiene deep-dive page —
+// populated further as PR7-9 add their own real medical-content pages.
 //
 // Shape: { [termKey]: { term, plainDefinition } }
 
@@ -36,5 +36,10 @@ export const glossary = {
     term: 'Catéter',
     plainDefinition:
       'Un tubo suave que tu médico coloca en tu abdomen, casi siempre cerca del ombligo. Por él entra y sale el líquido de diálisis.'
+  },
+  clorhexidina: {
+    term: 'Clorhexidina',
+    plainDefinition:
+      'Un antiséptico (un líquido que ayuda a evitar infecciones) que se usa para limpiar el sitio de salida de tu catéter. Tu clínica te indica cómo y cuándo usarlo.'
   }
 }

--- a/src/content/sources.js
+++ b/src/content/sources.js
@@ -3,9 +3,13 @@
 // fills in the verified URL for that entry and adds the remaining sources
 // named in spec R5.2 (ISPD 2022/2023, NKF, NIDDK) using the exact
 // URLs/dates captured during exploration (sdd/accessible-redesign/explore).
-// PR6-9 attach these sourceIds to real medical claims — currency should be
-// re-checked at that point per R5.7 (e.g. IMSS-797-16 is flagged in the
-// explore doc as possibly superseded by a newer edition).
+// PR6 fills in niddk-nutrition-pd's Spanish URL (verified during content
+// research, sdd/accessible-redesign/content-research) and adds who-five-keys
+// + medlineplus-pd for the hygiene deep-dive page's food-prep and
+// exit-site-infection claims. PR7-9 attach these sourceIds to real medical
+// claims — currency should be re-checked at that point per R5.7 (e.g.
+// IMSS-797-16 is flagged in the explore doc as possibly superseded by a
+// newer edition).
 //
 // Shape: { [sourceId]: { name, org, url, published, accessed } }
 
@@ -39,13 +43,28 @@ export const sources = {
     accessed: '2026-07-01'
   },
   'niddk-nutrition-pd': {
-    // Exact URL path was not captured verbatim during exploration (only the
-    // niddk.nih.gov domain + title were recorded) — verify this path before
-    // citing it in real PR6-9 content per R5.7.
-    name: 'Eating & Nutrition for Peritoneal Dialysis',
+    // URL verified during PR6 content research (sdd/accessible-redesign/
+    // content-research, section 2) — the official Spanish version of this
+    // page, preferred over the English one since the target audience is
+    // Spanish-speaking Mexico patients.
+    name: 'Alimentación y nutrición para la diálisis peritoneal',
     org: 'NIDDK (National Institute of Diabetes and Digestive and Kidney Diseases)',
-    url: null,
+    url: 'https://www.niddk.nih.gov/health-information/informacion-de-la-salud/enfermedades-rinones/insuficiencia-renal/dialisis-peritoneal/alimentacion-nutricion',
     published: '2018-08',
-    accessed: '2026-07-01'
+    accessed: '2026-07-02'
+  },
+  'who-five-keys': {
+    name: 'Manual sobre las cinco claves para la inocuidad de los alimentos',
+    org: 'OMS (Organización Mundial de la Salud)',
+    url: 'https://www.who.int/es/publications/i/item/9789241594639',
+    published: '2006',
+    accessed: '2026-07-02'
+  },
+  'medlineplus-pd': {
+    name: 'Diálisis - peritoneal',
+    org: 'MedlinePlus (Biblioteca Nacional de Medicina de EE. UU.)',
+    url: 'https://medlineplus.gov/spanish/ency/article/007434.htm',
+    published: '2024-10-28',
+    accessed: '2026-07-02'
   }
 }

--- a/src/content/sources.js
+++ b/src/content/sources.js
@@ -17,7 +17,12 @@ export const sources = {
   'imss-797-16': {
     name: 'Guía de práctica clínica IMSS-797-16: Intervenciones de enfermería para la atención y prevención de peritonitis infecciosa en adultos con diálisis peritoneal ambulatoria',
     org: 'IMSS',
-    url: 'http://www.imss.gob.mx/sites/all/statics/guiasclinicas/797GER.pdf',
+    // Points to the GRR (Guía de Referencia Rápida), not the GER — all
+    // hygiene claims cited to this source in PR6 were verified against the
+    // GRR document specifically (sdd/accessible-redesign/content-research
+    // section 6). PR7 reuses this same sourceId, so the URL must stay
+    // pinned to the document actually verified.
+    url: 'http://www.imss.gob.mx/sites/all/statics/guiasclinicas/797GRR.pdf',
     published: '2016',
     accessed: '2026-07-01'
   },

--- a/src/content/topics/higiene.js
+++ b/src/content/topics/higiene.js
@@ -1,0 +1,133 @@
+import React from 'react'
+import { TermTooltip } from '../../components/TermTooltip'
+
+// higiene: content data for the "Higiene" deep-dive topic page (PR6),
+// consumed by TopicPage (design section 1's topic shape). Every clinical
+// claim below traces to a claim in sdd/accessible-redesign/content-research
+// section 3a (hygiene) or 3b (exit-site infection escalation) — see the
+// mapping table in sdd/accessible-redesign/apply-progress. No numbers are
+// invented; the only numeric claim ("2 semanas") and the "70%" alcohol-gel
+// concentration are both source-stated (IMSS-797-16) — R5.5.
+//
+// Glossary terms (peritonitis, sitio de salida, catéter) are wrapped with
+// TermTooltip on first use only, in reading order — R5.4.
+
+export const higiene = {
+  title: 'Higiene',
+  description:
+    'Cómo lavarte las manos, cuidar tu catéter y mantener limpio tu espacio para prevenir infecciones.',
+  intro: (
+    <>
+      La higiene te ayuda a prevenir la{' '}
+      <TermTooltip termKey='peritonitis'>peritonitis</TermTooltip>: una
+      infección dentro del abdomen que puede pasar si entran microbios
+      durante tus intercambios. Lavarte las manos, cuidar tu piel y mantener
+      limpio tu espacio de trabajo ayuda a evitarla.
+    </>
+  ),
+  sourceIds: ['imss-797-16'],
+  sections: [
+    {
+      heading: 'Señales de infección en el sitio de salida',
+      body: (
+        <p>
+          El <TermTooltip termKey='sitioSalida'>sitio de salida</TermTooltip>{' '}
+          es el lugar de tu piel por donde sale tu{' '}
+          <TermTooltip termKey='cateter'>catéter</TermTooltip>. Revísalo
+          todos los días.
+        </p>
+      ),
+      warning: {
+        level: 'urgent',
+        text:
+          'Llama a tu clínica de inmediato si notas enrojecimiento, hinchazón, dolor, calor o pus alrededor del catéter.'
+      },
+      sourceIds: ['medlineplus-pd']
+    },
+    {
+      heading: 'Lávate las manos antes de cada intercambio',
+      body: (
+        <>
+          <p>
+            Lávate las manos con agua y jabón, o usa gel de alcohol etílico
+            al 70% antes de tocar tu material de diálisis.
+          </p>
+          <p>
+            Usa cubrebocas durante el intercambio. Lavarte las manos, usar
+            cubrebocas y seguir esta técnica limpia reduce el riesgo de
+            peritonitis.
+          </p>
+        </>
+      ),
+      sourceIds: ['imss-797-16']
+    },
+    {
+      heading: 'Cuida el sitio de salida y el catéter',
+      body: (
+        <>
+          <p>Haz la curación de tu sitio de salida todos los días.</p>
+          <p>
+            Mantén el sitio de salida seco y el catéter bien sujeto
+            (inmovilizado), para que no jale ni se mueva.
+          </p>
+          <p>
+            No mojes el sitio de salida ni el apósito (la gasa que lo cubre)
+            hasta que cicatrice. Esto suele tardar alrededor de 2 semanas.
+            Mientras tanto, báñate con cuidado para no mojar esa zona.
+          </p>
+          <p>
+            Usa antisépticos a base de clorhexidina para limpiar el sitio de
+            salida, según te lo indique tu clínica.
+          </p>
+          <p>
+            Cuando el sitio de salida ya cicatrizó, lávalo todos los días con
+            jabón antibacterial o con el antiséptico que te recomiende tu
+            clínica.
+          </p>
+          <p>
+            Mantén tus manos y uñas limpias; tu equipo de salud revisa esto
+            en cada visita.
+          </p>
+        </>
+      ),
+      sourceIds: ['imss-797-16']
+    },
+    {
+      heading: 'Mantén limpio tu espacio de intercambio',
+      body: (
+        <>
+          <p>
+            Limpia y sacude el polvo de tu espacio de intercambio todos los
+            días: paredes, piso y superficies donde guardas tu material de
+            diálisis.
+          </p>
+          <p>
+            No tengas mascotas ni plantas en el cuarto donde haces tus
+            intercambios. Pueden traer microbios que contaminan el
+            ambiente.
+          </p>
+        </>
+      ),
+      sourceIds: ['imss-797-16', 'ispd-peritonitis-2022']
+    },
+    {
+      heading: 'Prepara tus alimentos con higiene',
+      body: (
+        <>
+          <p>
+            La Organización Mundial de la Salud recomienda seguir cinco
+            reglas al preparar tus alimentos:
+          </p>
+          <ul>
+            <li>Mantén la limpieza.</li>
+            <li>Separa los alimentos crudos de los cocinados.</li>
+            <li>Cocina completamente los alimentos.</li>
+            <li>Mantén los alimentos a temperaturas seguras.</li>
+            <li>Usa agua y materias primas seguras.</li>
+          </ul>
+        </>
+      ),
+      sourceIds: ['who-five-keys']
+    }
+  ]
+}

--- a/src/content/topics/higiene.js
+++ b/src/content/topics/higiene.js
@@ -9,8 +9,8 @@ import { TermTooltip } from '../../components/TermTooltip'
 // invented; the only numeric claim ("2 semanas") and the "70%" alcohol-gel
 // concentration are both source-stated (IMSS-797-16) — R5.5.
 //
-// Glossary terms (peritonitis, sitio de salida, catéter) are wrapped with
-// TermTooltip on first use only, in reading order — R5.4.
+// Glossary terms (peritonitis, sitio de salida, catéter, clorhexidina) are
+// wrapped with TermTooltip on first use only, in reading order — R5.4.
 
 export const higiene = {
   title: 'Higiene',
@@ -33,8 +33,7 @@ export const higiene = {
         <p>
           El <TermTooltip termKey='sitioSalida'>sitio de salida</TermTooltip>{' '}
           es el lugar de tu piel por donde sale tu{' '}
-          <TermTooltip termKey='cateter'>catéter</TermTooltip>. Revísalo
-          todos los días.
+          <TermTooltip termKey='cateter'>catéter</TermTooltip>.
         </p>
       ),
       warning: {
@@ -65,7 +64,9 @@ export const higiene = {
       heading: 'Cuida el sitio de salida y el catéter',
       body: (
         <>
-          <p>Haz la curación de tu sitio de salida todos los días.</p>
+          <p>
+            Revisa tu sitio de salida y haz la curación todos los días.
+          </p>
           <p>
             Mantén el sitio de salida seco y el catéter bien sujeto
             (inmovilizado), para que no jale ni se mueva.
@@ -76,8 +77,9 @@ export const higiene = {
             Mientras tanto, báñate con cuidado para no mojar esa zona.
           </p>
           <p>
-            Usa antisépticos a base de clorhexidina para limpiar el sitio de
-            salida, según te lo indique tu clínica.
+            Usa antisépticos a base de{' '}
+            <TermTooltip termKey='clorhexidina'>clorhexidina</TermTooltip>{' '}
+            para limpiar el sitio de salida, según te lo indique tu clínica.
           </p>
           <p>
             Cuando el sitio de salida ya cicatrizó, lávalo todos los días con

--- a/src/pages/Higiene.js
+++ b/src/pages/Higiene.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Layout } from '../components/Layout'
+import { TopicPage } from '../components/TopicPage'
+import { higiene } from '../content/topics/higiene'
+
+// Higiene: real content page at /cuidados/higiene (PR6), replacing the
+// TopicComingSoon placeholder scaffolded in PR5a. Layout provides the
+// skip-link landmark (R6.2); TopicPage composes intro -> core guidance ->
+// warning/escalation -> citations (R5.1).
+export const Higiene = () => (
+  <Layout title={higiene.title} description={higiene.description}>
+    <TopicPage {...higiene} />
+  </Layout>
+)

--- a/src/routes/RouteList.js
+++ b/src/routes/RouteList.js
@@ -7,6 +7,7 @@ import { WaterRecycling } from '../pages/WaterRecycling'
 import { ProcedimientosIndex } from '../pages/ProcedimientosIndex'
 import { CuidadosIndex } from '../pages/CuidadosIndex'
 import { AlimentacionIndex } from '../pages/AlimentacionIndex'
+import { Higiene } from '../pages/Higiene'
 import { TopicComingSoon } from '../pages/TopicComingSoon'
 import { NoMatch } from '../pages/NoMatch'
 
@@ -25,15 +26,7 @@ export const RouteList = () => (
     <Route path='/procedimientos' element={<ProcedimientosIndex />} />
 
     <Route path='/cuidados' element={<CuidadosIndex />} />
-    <Route
-      path='/cuidados/higiene'
-      element={
-        <TopicComingSoon
-          title='Higiene'
-          description='Cuidado de la piel, el catéter y la herida.'
-        />
-      }
-    />
+    <Route path='/cuidados/higiene' element={<Higiene />} />
     <Route
       path='/cuidados/senales-de-alarma'
       element={


### PR DESCRIPTION
Part of #3 (PR6 of the accessible-redesign chain — stacked on #10; first medical-content slice)

## Summary

Real content at `/cuidados/higiene` (replaces the placeholder), built on the TopicPage template:

- **Lavado de manos**: soap/water + 70% alcohol gel, mask use, aseptic technique (IMSS-797-16)
- **Cuidado del sitio de salida**: daily care, keep dry + catheter immobilized, no wetting until healed (~2 semanas — source-stated), chlorhexidine antiseptics, after-healing routine, nail/hand hygiene
- **Ambiente limpio**: daily cleaning of the exchange area; no pets/plants in the room (IMSS + ISPD 2022)
- **Preparación segura de alimentos**: WHO "Cinco claves para la inocuidad de los alimentos" (official Spanish source)
- UrgentWarningCallout with exit-site infection signs ("llama a tu clínica") placed FIRST after the intro
- Glossary: sitio de salida, catéter, clorhexidina added and TermTooltip-linked on first use
- Bonus fix: TopicPage rendered a duplicate h1 (template bug from PR5b) — now h2/h3, benefiting PR7–9

## Medical-accuracy gate (spec R5.7)

- (a) Every clinical claim traces to a claim packet in the verified research record (IMSS-797-16 GRR, ISPD 2022, WHO, MedlinePlus, NIDDK-ES) — audited claim-by-claim by an independent fresh-context review; one mis-attribution found and corrected before this PR was opened
- (b) Escalation warning high on the page; disclaimer renders on every topic page
- (c) No invented numeric thresholds — the only numbers ("70%", "2 semanas") are source-stated
- (d) Owner sign-off = merging this PR

## Test plan

- [x] `npm test`: 95/95 green (13 suites)
- [x] `npm run build` passes
- [x] Independent claim-by-claim audit: PASS after corrective pass (3 warnings fixed: citation re-attribution, IMSS URL now points to the exact GRR document all claims were verified against, clorhexidina glossary link)