### PR TITLE
feat(content): peritonitis warning signs page with escalation table

### DIFF
--- a/__tests__/RouteList.test.js
+++ b/__tests__/RouteList.test.js
@@ -41,7 +41,6 @@ describe('RouteList', () => {
   })
 
   it.each([
-    '/cuidados/senales-de-alarma',
     '/alimentacion/liquidos',
     '/alimentacion/nutricion'
   ])('renders the topic placeholder at %s under Layout', (path) => {
@@ -55,6 +54,15 @@ describe('RouteList', () => {
     expect(screen.getByRole('main')).toBeInTheDocument()
     expect(
       screen.getByRole('heading', { name: 'Higiene', level: 1 })
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/preparando esta guía/)).not.toBeInTheDocument()
+  })
+
+  it('renders the real Señales de alarma content page at /cuidados/senales-de-alarma under Layout', () => {
+    renderAt('/cuidados/senales-de-alarma')
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Señales de alarma', level: 1 })
     ).toBeInTheDocument()
     expect(screen.queryByText(/preparando esta guía/)).not.toBeInTheDocument()
   })

--- a/__tests__/SenalesAlarma.test.js
+++ b/__tests__/SenalesAlarma.test.js
@@ -1,0 +1,113 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { RouteList } from '../src/routes/RouteList'
+
+const renderSenalesAlarma = () =>
+  render(
+    <MemoryRouter initialEntries={['/cuidados/senales-de-alarma']}>
+      <RouteList />
+    </MemoryRouter>
+  )
+
+// SenalesAlarma: real content page at /cuidados/senales-de-alarma (PR7) —
+// R5.1, R5.3, R5.7.
+describe('SenalesAlarma page', () => {
+  it('renders under Layout at its route with the page title', () => {
+    renderSenalesAlarma()
+
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Señales de alarma', level: 1 })
+    ).toBeInTheDocument()
+  })
+
+  it('places the escalation table immediately after the intro, before the explanatory sign list (R5.3)', () => {
+    renderSenalesAlarma()
+
+    const headings = screen
+      .getAllByRole('heading', { level: 3 })
+      .map((heading) => heading.textContent)
+
+    const immediateIndex = headings.indexOf('Llama a tu clínica de inmediato')
+    const alsoIndex = headings.indexOf('También llama a tu clínica si...')
+    const explanatoryIndex = headings.indexOf('Señales de alarma de peritonitis')
+
+    expect(immediateIndex).toBe(0)
+    expect(alsoIndex).toBe(1)
+    expect(explanatoryIndex).toBeGreaterThan(alsoIndex)
+  })
+
+  it('renders both escalation tiers as tables with icon+text "Llama a tu clínica" actions', () => {
+    renderSenalesAlarma()
+
+    const tables = screen.getAllByRole('table')
+    expect(tables).toHaveLength(2)
+
+    expect(
+      screen.getByText(/Enrojecimiento, hinchazón, dolor, calor o pus/)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Líquido de diálisis turbio o de color anormal')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Comezón intensa')).toBeInTheDocument()
+    expect(
+      screen.getByText('Cualquier molestia que dure más de 2 días')
+    ).toBeInTheDocument()
+    expect(screen.getAllByText('Llama a tu clínica').length).toBeGreaterThan(0)
+    // No ER-specific criterion is invented on this page — every action is
+    // "call your clinic", not "go to the ER".
+    expect(screen.queryByText('Ve a urgencias')).not.toBeInTheDocument()
+  })
+
+  it('gives generic emergency-room navigation guidance if the clinic is unreachable', () => {
+    renderSenalesAlarma()
+
+    expect(
+      screen.getByText(/no logras comunicarte con tu clínica/)
+    ).toBeInTheDocument()
+    expect(screen.getByText(/acude a un servicio de urgencias/)).toBeInTheDocument()
+  })
+
+  it('renders the explanatory IMSS-797-16 warning-sign list as icon+text items', () => {
+    renderSenalesAlarma()
+
+    expect(screen.getByText('Náusea')).toBeInTheDocument()
+    expect(screen.getByText('Vómito')).toBeInTheDocument()
+    expect(screen.getByText('Diarrea')).toBeInTheDocument()
+    // "Fiebre" also appears once as an escalation-table symptom row —
+    // both instances are expected on this page (tier 1 table + explanatory
+    // sign list).
+    expect(screen.getAllByText('Fiebre').length).toBe(2)
+    expect(screen.getByText('Líquido de diálisis turbio')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Dolor de panza \(abdominal\) generalizado/)
+    ).toBeInTheDocument()
+  })
+
+  it('resolves citations and always shows the clinic/nephrologist disclaimer', () => {
+    renderSenalesAlarma()
+
+    expect(
+      screen.getByRole('link', { name: /Guía de práctica clínica IMSS-797-16/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /Diálisis - peritoneal/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/no reemplaza las indicaciones de tu clínica/)
+    ).toBeInTheDocument()
+  })
+
+  it('glossary-links peritonitis, efluente and hiporexia on first use', () => {
+    renderSenalesAlarma()
+
+    expect(
+      screen.getByRole('button', { name: 'peritonitis' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'líquido de diálisis (efluente)' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'hiporexia' })).toBeInTheDocument()
+  })
+})

--- a/__tests__/SenalesAlarma.test.js
+++ b/__tests__/SenalesAlarma.test.js
@@ -99,7 +99,7 @@ describe('SenalesAlarma page', () => {
     ).toBeInTheDocument()
   })
 
-  it('glossary-links peritonitis, efluente and hiporexia on first use', () => {
+  it('glossary-links peritonitis, efluente, catéter and hiporexia on first use', () => {
     renderSenalesAlarma()
 
     expect(
@@ -108,6 +108,7 @@ describe('SenalesAlarma page', () => {
     expect(
       screen.getByRole('button', { name: 'líquido de diálisis (efluente)' })
     ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'catéter' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'hiporexia' })).toBeInTheDocument()
   })
 })

--- a/__tests__/SignList.test.js
+++ b/__tests__/SignList.test.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { SignList } from '../src/components/SignList'
+
+const items = [
+  { id: 'nausea', text: 'Náusea' },
+  { id: 'fiebre', text: 'Fiebre' }
+]
+
+// SignList: plain-language icon+text symptom list — R5.4. Meaning is never
+// conveyed by icon alone: every item pairs a visible icon (aria-hidden,
+// decorative) with visible text.
+describe('SignList', () => {
+  it('renders every item as visible text', () => {
+    render(<SignList items={items} />)
+
+    expect(screen.getByText('Náusea')).toBeInTheDocument()
+    expect(screen.getByText('Fiebre')).toBeInTheDocument()
+  })
+
+  it('renders a decorative icon per item that is hidden from assistive tech', () => {
+    const { container } = render(<SignList items={items} />)
+
+    const icons = container.querySelectorAll('[aria-hidden="true"]')
+    expect(icons).toHaveLength(items.length)
+  })
+
+  it('renders nothing when items is empty', () => {
+    const { container } = render(<SignList items={[]} />)
+
+    expect(container.querySelectorAll('li')).toHaveLength(0)
+  })
+})

--- a/src/components/SignList/index.js
+++ b/src/components/SignList/index.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { MdReportProblem } from 'react-icons/md'
+import { List, ListItem, ItemIcon, ItemText } from './styles'
+
+// SignList: plain-language symptom/warning-sign list — R5.4. Every item
+// pairs a visible icon with visible text so meaning is never conveyed by
+// icon or text alone, matching the icon+text redundancy pattern already
+// used by UrgentWarningCallout and EscalationTable's action badges. One
+// consistent icon per item (not a different icon per symptom) since this
+// list carries no per-item severity distinction — it's a scanability aid,
+// not a color/icon-coded warning system. `items` shape: `[{ id, text }]`.
+export const SignList = ({ items = [] }) => (
+  <List>
+    {items.map(({ id, text }) => (
+      <ListItem key={id}>
+        <ItemIcon aria-hidden='true'>
+          <MdReportProblem />
+        </ItemIcon>
+        <ItemText>{text}</ItemText>
+      </ListItem>
+    ))}
+  </List>
+)

--- a/src/components/SignList/styles.js
+++ b/src/components/SignList/styles.js
@@ -1,0 +1,31 @@
+import styled from 'styled-components'
+
+export const List = styled.ul`
+  list-style: none;
+  margin: var(--spacing-md) 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+`
+
+export const ListItem = styled.li`
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+`
+
+export const ItemIcon = styled.span`
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  color: var(--color-caution);
+  font-size: var(--font-size-lg);
+  line-height: 1.6;
+`
+
+export const ItemText = styled.span`
+  color: var(--color-primary);
+  font-size: var(--font-size-base);
+  line-height: 1.6;
+`

--- a/src/content/glossary.js
+++ b/src/content/glossary.js
@@ -1,8 +1,9 @@
 // glossary: clinical/brand term definitions for the tap-to-expand glossary
 // primitive (R4.3). Seed entries added in PR3 (exsept, mupirocina); expanded
 // in PR5b (heparina, peritonitis) alongside the TermTooltip component itself.
-// PR6 adds sitioSalida/cateter/clorhexidina for the hygiene deep-dive page —
-// populated further as PR7-9 add their own real medical-content pages.
+// PR6 adds sitioSalida/cateter/clorhexidina for the hygiene deep-dive page.
+// PR7 adds efluente/hiporexia for the warning-signs + escalation page —
+// populated further as PR8-9 add their own real medical-content pages.
 //
 // Shape: { [termKey]: { term, plainDefinition } }
 
@@ -41,5 +42,14 @@ export const glossary = {
     term: 'Clorhexidina',
     plainDefinition:
       'Un antiséptico (un líquido que ayuda a evitar infecciones) que se usa para limpiar el sitio de salida de tu catéter. Tu clínica te indica cómo y cuándo usarlo.'
+  },
+  efluente: {
+    term: 'Efluente (líquido turbio)',
+    plainDefinition:
+      'El líquido de diálisis que sale de tu abdomen después de un intercambio. Si sale turbio (nublado) o de un color distinto al habitual, puede ser señal de peritonitis. No esperes: llama a tu clínica de inmediato.'
+  },
+  hiporexia: {
+    term: 'Hiporexia',
+    plainDefinition: 'Tener poco apetito o ganas de comer.'
   }
 }

--- a/src/content/topics/senales-alarma.js
+++ b/src/content/topics/senales-alarma.js
@@ -52,8 +52,12 @@ export const senalesAlarma = {
         items: [
           {
             id: 'exit-site-infection',
-            symptom:
-              'Enrojecimiento, hinchazón, dolor, calor o pus alrededor de tu catéter',
+            symptom: (
+              <>
+                Enrojecimiento, hinchazón, dolor, calor o pus alrededor de tu{' '}
+                <TermTooltip termKey='cateter'>catéter</TermTooltip>
+              </>
+            ),
             action: 'clinic'
           },
           { id: 'fever', symptom: 'Fiebre', action: 'clinic' },

--- a/src/content/topics/senales-alarma.js
+++ b/src/content/topics/senales-alarma.js
@@ -1,0 +1,155 @@
+import React from 'react'
+import { TermTooltip } from '../../components/TermTooltip'
+import { SignList } from '../../components/SignList'
+
+// senales-alarma: content data for the "Señales de alarma" (peritonitis
+// warning-signs + escalation) topic page (PR7), consumed by TopicPage.
+// Every clinical claim below traces to sdd/accessible-redesign/
+// content-research section 3b (peritonitis) or section 4 (glossary) — see
+// the mapping table in sdd/accessible-redesign/apply-progress. No numbers
+// are invented; "más de 2 días" is source-stated (MedlinePlus) — R5.5.
+//
+// R5.3 hard requirement for this page: the escalation table must be
+// reachable within normal mobile scrolling, placed immediately after the
+// 1-paragraph intro and before any explanatory content. Section order below
+// is therefore: intro -> escalation (immediate tier) -> escalation (also
+// tier) -> what to do if you can't reach your clinic -> explanatory sign
+// list (IMSS-797-16) — the last section is the only "explanatory" one, and
+// it comes after every escalation section.
+//
+// Escalation framing (per task instruction, no ER-specific criterion list
+// exists in the research): both tiers are "call your clinic" — an
+// immediate-contact tier and a less-urgent "also call" tier — not a
+// clinic-vs-ER split. `EscalationTable`'s `action: 'clinic'` is used for
+// every row on this page; `action: 'er'` is intentionally not used here.
+export const senalesAlarma = {
+  title: 'Señales de alarma',
+  description:
+    'Qué señales pueden indicar una infección (peritonitis) y cuándo llamar a tu clínica.',
+  intro: (
+    <>
+      La <TermTooltip termKey='peritonitis'>peritonitis</TermTooltip> es la
+      complicación más frecuente en diálisis peritoneal. Cuando aparecen
+      señales de alarma, actuar rápido ayuda a que tu clínica la trate a
+      tiempo. Aquí encuentras qué señales vigilar y cuándo llamar.
+    </>
+  ),
+  sourceIds: ['imss-797-16'],
+  sections: [
+    {
+      heading: 'Llama a tu clínica de inmediato',
+      body: (
+        <p>
+          Si notas cualquiera de estas señales, comunícate con tu clínica de
+          inmediato. No esperes, sobre todo si tu{' '}
+          <TermTooltip termKey='efluente'>
+            líquido de diálisis (efluente)
+          </TermTooltip>{' '}
+          sale turbio o de un color distinto al habitual.
+        </p>
+      ),
+      table: {
+        items: [
+          {
+            id: 'exit-site-infection',
+            symptom:
+              'Enrojecimiento, hinchazón, dolor, calor o pus alrededor de tu catéter',
+            action: 'clinic'
+          },
+          { id: 'fever', symptom: 'Fiebre', action: 'clinic' },
+          { id: 'nausea-vomiting', symptom: 'Náusea o vómito', action: 'clinic' },
+          {
+            id: 'cloudy-fluid',
+            symptom: 'Líquido de diálisis turbio o de color anormal',
+            action: 'clinic'
+          },
+          {
+            id: 'no-gas-bowel',
+            symptom: 'No poder expulsar gases ni evacuar',
+            action: 'clinic'
+          }
+        ]
+      },
+      sourceIds: ['medlineplus-pd']
+    },
+    {
+      heading: 'También llama a tu clínica si...',
+      body: (
+        <p>
+          Estas señales son menos urgentes, pero también debes avisar a tu
+          clínica — sobre todo si duran más de 2 días.
+        </p>
+      ),
+      table: {
+        items: [
+          { id: 'severe-itching', symptom: 'Comezón intensa', action: 'clinic' },
+          {
+            id: 'sleep-problems',
+            symptom: 'Problemas para dormir',
+            action: 'clinic'
+          },
+          {
+            id: 'diarrhea-constipation',
+            symptom: 'Diarrea o estreñimiento',
+            action: 'clinic'
+          },
+          {
+            id: 'drowsiness-confusion',
+            symptom: 'Somnolencia o confusión',
+            action: 'clinic'
+          },
+          {
+            id: 'lasting-2-days',
+            symptom: 'Cualquier molestia que dure más de 2 días',
+            action: 'clinic'
+          }
+        ]
+      },
+      sourceIds: ['medlineplus-pd']
+    },
+    {
+      heading: 'Si no localizas a tu clínica',
+      body: (
+        <p>
+          Si no logras comunicarte con tu clínica y sientes que tu situación
+          es grave, acude a un servicio de urgencias.
+        </p>
+      )
+    },
+    {
+      heading: 'Señales de alarma de peritonitis',
+      body: (
+        <>
+          <p>
+            Estas son las señales de alarma que debes vigilar, según la guía
+            de IMSS para diálisis peritoneal:
+          </p>
+          <SignList
+            items={[
+              { id: 'nausea', text: 'Náusea' },
+              { id: 'vomito', text: 'Vómito' },
+              {
+                id: 'apetito',
+                text: (
+                  <>
+                    Poco apetito (
+                    <TermTooltip termKey='hiporexia'>hiporexia</TermTooltip>)
+                  </>
+                )
+              },
+              { id: 'diarrea', text: 'Diarrea' },
+              {
+                id: 'dolor-abdominal',
+                text:
+                  'Dolor de panza (abdominal) generalizado, que no se siente en un solo punto'
+              },
+              { id: 'fiebre', text: 'Fiebre' },
+              { id: 'liquido-turbio', text: 'Líquido de diálisis turbio' }
+            ]}
+          />
+        </>
+      ),
+      sourceIds: ['imss-797-16']
+    }
+  ]
+}

--- a/src/pages/SenalesAlarma.js
+++ b/src/pages/SenalesAlarma.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Layout } from '../components/Layout'
+import { TopicPage } from '../components/TopicPage'
+import { senalesAlarma } from '../content/topics/senales-alarma'
+
+// SenalesAlarma: real content page at /cuidados/senales-de-alarma (PR7),
+// replacing the TopicComingSoon placeholder scaffolded in PR5a. Layout
+// provides the skip-link landmark (R6.2); TopicPage composes intro ->
+// escalation (R5.3, placed first) -> explanatory sign list -> citations
+// (R5.1).
+export const SenalesAlarma = () => (
+  <Layout title={senalesAlarma.title} description={senalesAlarma.description}>
+    <TopicPage {...senalesAlarma} />
+  </Layout>
+)

--- a/src/routes/RouteList.js
+++ b/src/routes/RouteList.js
@@ -8,6 +8,7 @@ import { ProcedimientosIndex } from '../pages/ProcedimientosIndex'
 import { CuidadosIndex } from '../pages/CuidadosIndex'
 import { AlimentacionIndex } from '../pages/AlimentacionIndex'
 import { Higiene } from '../pages/Higiene'
+import { SenalesAlarma } from '../pages/SenalesAlarma'
 import { TopicComingSoon } from '../pages/TopicComingSoon'
 import { NoMatch } from '../pages/NoMatch'
 
@@ -27,15 +28,7 @@ export const RouteList = () => (
 
     <Route path='/cuidados' element={<CuidadosIndex />} />
     <Route path='/cuidados/higiene' element={<Higiene />} />
-    <Route
-      path='/cuidados/senales-de-alarma'
-      element={
-        <TopicComingSoon
-          title='Señales de alarma'
-          description='Qué observar y cuándo buscar ayuda.'
-        />
-      }
-    />
+    <Route path='/cuidados/senales-de-alarma' element={<SenalesAlarma />} />
 
     <Route path='/alimentacion' element={<AlimentacionIndex />} />
     <Route


### PR DESCRIPTION
Part of #3 (PR7 of the accessible-redesign chain — stacked on #11)

## Summary

Real content at `/cuidados/senales-de-alarma` — the page a scared caregiver opens at 2 AM:

- **Escalation table FIRST** (spec R5.3 explicit scenario): one short intro paragraph, then "Llama a tu clínica de inmediato" (cloudy/abnormal drained fluid, fever, nausea/vomiting, exit-site infection signs, inability to pass gas/stool — MedlinePlus) and the second tier "También llama si..." (severe itching, sleep problems, drowsiness/confusion, anything lasting more than 2 days)
- The 7-sign IMSS-797-16 warning list (náusea, vómito, poco apetito, diarrea, dolor abdominal difuso, fiebre, líquido turbio) as an icon+text SignList — new reusable primitive
- "Do not wait" framing for cloudy fluid; ER fallback kept as generic navigation guidance because **no source states ER-specific clinical criteria** — nothing invented
- Glossary: efluente, hiporexia added; catéter linked (corrective commit after the independent audit)

## Medical-accuracy gate (spec R5.7)

- (a) Independent claim-by-claim audit: every clinical statement traces to the verified research (IMSS-797-16 GRR sign list matched exactly; MedlinePlus tiers verbatim); the 2 intentionally-unsourced rows are navigation/framing copy, judged non-clinical
- (b) Escalation table reachable within normal mobile scroll — verified against the explicit spec scenario, asserted in tests
- (c) No invented numbers, signs, or ER criteria
- (d) Owner sign-off = merging this PR

## Test plan

- [x] `npm test`: 105/105 green (15 suites)
- [x] `npm run build` passes
- [x] Independent fresh-context review: PASS — 0 critical; 1 warning (glossary link) fixed before opening