### PR TITLE
feat(content): fluid management and swelling page — misconception loop, no-blame framing

### DIFF
--- a/__tests__/Liquidos.test.js
+++ b/__tests__/Liquidos.test.js
@@ -1,0 +1,142 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { RouteList } from '../src/routes/RouteList'
+
+const renderLiquidos = () =>
+  render(
+    <MemoryRouter initialEntries={['/alimentacion/liquidos']}>
+      <RouteList />
+    </MemoryRouter>
+  )
+
+// A fluid-volume number would violate R5.5's hard rule for this page (no
+// fixed mL/oz-per-day limit — content-research section 3c confirms no
+// PD-specific source states a universal figure). Matches "<digits> ml",
+// "<digits> mililitros", "<digits> litros/L", "<digits> oz/onzas", whether
+// or not "por día" follows, so any invented threshold is caught regardless
+// of phrasing.
+const FLUID_VOLUME_NUMBER = /\d+\s?(ml|mililitros?|litros?|l\b|oz|onzas?)\b/i
+
+// Liquidos: real content page at /alimentacion/liquidos (PR8) — R5.1, R5.5,
+// R5.6, R5.7.
+describe('Liquidos page', () => {
+  it('renders under Layout at its route with the page title', () => {
+    renderLiquidos()
+
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Líquidos', level: 1 })
+    ).toBeInTheDocument()
+  })
+
+  it('places fluid-overload warning signs before the misconception-loop explanation', () => {
+    renderLiquidos()
+
+    const headings = screen
+      .getAllByRole('heading', { level: 3 })
+      .map((heading) => heading.textContent)
+
+    const signsIndex = headings.findIndex((text) =>
+      text.includes('retención de líquido')
+    )
+    const whyIndex = headings.findIndex((text) => text.includes('Por qué'))
+    const whatIndex = headings.findIndex((text) =>
+      text.includes('Qué puedes hacer')
+    )
+
+    expect(signsIndex).toBe(0)
+    expect(whyIndex).toBeGreaterThan(signsIndex)
+    expect(whatIndex).toBeGreaterThan(whyIndex)
+  })
+
+  it('renders the fluid-overload sign list as icon+text items (NKF)', () => {
+    renderLiquidos()
+
+    expect(screen.getByText(/pies, tobillos, muñecas o cara/)).toBeInTheDocument()
+    expect(
+      screen.getByText(/[Ff]alta de aire|dificultad para respirar/)
+    ).toBeInTheDocument()
+    expect(screen.getByText(/[Cc]alambres/)).toBeInTheDocument()
+    expect(screen.getByText(/[Dd]olor de cabeza/)).toBeInTheDocument()
+    expect(screen.getByText(/hinchazón \(distensión\) abdominal/i)).toBeInTheDocument()
+  })
+
+  it('warns urgently on a change in swelling pattern or trouble breathing, directing to the clinic (R5.6)', () => {
+    renderLiquidos()
+
+    expect(screen.getByText('Urgente')).toBeInTheDocument()
+    expect(
+      screen.getByText(/cambio en cómo se hincha tu cuerpo/)
+    ).toBeInTheDocument()
+    expect(screen.getByText(/cuesta trabajo respirar/)).toBeInTheDocument()
+    expect(screen.getAllByText(/llama a tu clínica/i).length).toBeGreaterThan(0)
+  })
+
+  it('presents non-behavioral causes of swelling without blaming the patient (R5.6)', () => {
+    renderLiquidos()
+
+    // No-blame: the page must not default to "you drank too much" framing.
+    expect(screen.queryByText(/tomaste demasiado líquido/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/tomar demasiado líquido/i)).not.toBeInTheDocument()
+
+    // Non-behavioral cause 1: sodium makes the body retain water.
+    expect(
+      screen.getByRole('button', { name: 'sal (sodio)', hidden: true })
+    ).toBeInTheDocument()
+    expect(screen.getByText(/retenga agua/)).toBeInTheDocument()
+
+    // Non-behavioral cause 2: ultrafiltration can vary/fail for medical reasons.
+    expect(
+      screen.getByRole('button', { name: 'ultrafiltración', hidden: true })
+    ).toBeInTheDocument()
+    expect(screen.getByText(/uremia/i)).toBeInTheDocument()
+
+    // Non-behavioral cause 3: the membrane's filtering can change over years.
+    expect(screen.getByText(/con los años/i)).toBeInTheDocument()
+  })
+
+  it('frames the fluid goal as individualized with no fixed daily number (R5.5)', () => {
+    renderLiquidos()
+
+    expect(
+      screen.getAllByText(/nutriólogo|dietista/i).length
+    ).toBeGreaterThan(0)
+    expect(
+      screen.getAllByText(/meta (diaria )?de líquidos/i).length
+    ).toBeGreaterThan(0)
+
+    const main = screen.getByRole('main')
+    expect(main.textContent).not.toMatch(FLUID_VOLUME_NUMBER)
+  })
+
+  it('mentions daily weight monitoring as self-care (IMSS-797-16)', () => {
+    renderLiquidos()
+
+    expect(screen.getByText(/[Pp]ésate todos los días/)).toBeInTheDocument()
+  })
+
+  it('resolves citations and always shows the clinic/nephrologist disclaimer', () => {
+    renderLiquidos()
+
+    expect(
+      screen.getByRole('link', { name: /Fluid Overload in a Dialysis Patient/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /Ultrafiltration/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /Alimentación y nutrición/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/no reemplaza las indicaciones de tu clínica/)
+    ).toBeInTheDocument()
+  })
+
+  it('never uses a fixed mL/oz-per-day fluid number anywhere on the page (R5.5 hard rule)', () => {
+    renderLiquidos()
+
+    const main = screen.getByRole('main')
+    expect(main.textContent).not.toMatch(FLUID_VOLUME_NUMBER)
+  })
+})

--- a/__tests__/Liquidos.test.js
+++ b/__tests__/Liquidos.test.js
@@ -13,10 +13,23 @@ const renderLiquidos = () =>
 // A fluid-volume number would violate R5.5's hard rule for this page (no
 // fixed mL/oz-per-day limit — content-research section 3c confirms no
 // PD-specific source states a universal figure). Matches "<digits> ml",
-// "<digits> mililitros", "<digits> litros/L", "<digits> oz/onzas", whether
-// or not "por día" follows, so any invented threshold is caught regardless
-// of phrasing.
-const FLUID_VOLUME_NUMBER = /\d+\s?(ml|mililitros?|litros?|l\b|oz|onzas?)\b/i
+// "<digits> mililitros", "<digits> litros/L", "<digits> oz/onzas", and
+// glass/cup phrasings ("<digits> vasos", "<digits> tazas" — e.g. "4 vasos
+// al día"), whether or not "al día"/"por día" follows, so any invented
+// threshold is caught regardless of unit or phrasing (PR8 gate review
+// corrective pass — the original alternation missed cup-based limits).
+const FLUID_VOLUME_NUMBER =
+  /\d+\s?(ml|mililitros?|litros?|l\b|oz|onzas?|vasos?|tazas?)\b/i
+
+// Meta-test: guards the guard — confirms the regex itself would catch a
+// cup-based fluid limit before relying on it to scan the rendered page.
+describe('FLUID_VOLUME_NUMBER regex', () => {
+  it('matches glass/cup-based fluid limits, not just ml/l/oz', () => {
+    expect('4 vasos al día').toMatch(FLUID_VOLUME_NUMBER)
+    expect('2 tazas por día').toMatch(FLUID_VOLUME_NUMBER)
+    expect('1500 ml al día').toMatch(FLUID_VOLUME_NUMBER)
+  })
+})
 
 // Liquidos: real content page at /alimentacion/liquidos (PR8) — R5.1, R5.5,
 // R5.6, R5.7.

--- a/__tests__/RouteList.test.js
+++ b/__tests__/RouteList.test.js
@@ -41,7 +41,6 @@ describe('RouteList', () => {
   })
 
   it.each([
-    '/alimentacion/liquidos',
     '/alimentacion/nutricion'
   ])('renders the topic placeholder at %s under Layout', (path) => {
     renderAt(path)
@@ -63,6 +62,15 @@ describe('RouteList', () => {
     expect(screen.getByRole('main')).toBeInTheDocument()
     expect(
       screen.getByRole('heading', { name: 'Señales de alarma', level: 1 })
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/preparando esta guía/)).not.toBeInTheDocument()
+  })
+
+  it('renders the real Líquidos content page at /alimentacion/liquidos under Layout', () => {
+    renderAt('/alimentacion/liquidos')
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Líquidos', level: 1 })
     ).toBeInTheDocument()
     expect(screen.queryByText(/preparando esta guía/)).not.toBeInTheDocument()
   })

--- a/src/content/glossary.js
+++ b/src/content/glossary.js
@@ -2,8 +2,9 @@
 // primitive (R4.3). Seed entries added in PR3 (exsept, mupirocina); expanded
 // in PR5b (heparina, peritonitis) alongside the TermTooltip component itself.
 // PR6 adds sitioSalida/cateter/clorhexidina for the hygiene deep-dive page.
-// PR7 adds efluente/hiporexia for the warning-signs + escalation page —
-// populated further as PR8-9 add their own real medical-content pages.
+// PR7 adds efluente/hiporexia for the warning-signs + escalation page. PR8
+// adds sodio/ultrafiltracion for the fluid-management + swelling page —
+// populated further as PR9 adds its own real medical-content page.
 //
 // Shape: { [termKey]: { term, plainDefinition } }
 
@@ -51,5 +52,15 @@ export const glossary = {
   hiporexia: {
     term: 'Hiporexia',
     plainDefinition: 'Tener poco apetito o ganas de comer.'
+  },
+  sodio: {
+    term: 'Sodio',
+    plainDefinition:
+      'Un mineral que forma parte de la sal. Se encuentra en grandes cantidades en alimentos enlatados, empaquetados, congelados y de comida rápida, y en los condimentos. Hace que tu cuerpo retenga agua y aumenta la sed.'
+  },
+  ultrafiltracion: {
+    term: 'Ultrafiltración',
+    plainDefinition:
+      'El proceso con el que se saca líquido de tu cuerpo durante un intercambio de diálisis peritoneal. Depende de la concentración de dextrosa (azúcar) del líquido de diálisis que usas.'
   }
 }

--- a/src/content/sources.js
+++ b/src/content/sources.js
@@ -6,10 +6,11 @@
 // PR6 fills in niddk-nutrition-pd's Spanish URL (verified during content
 // research, sdd/accessible-redesign/content-research) and adds who-five-keys
 // + medlineplus-pd for the hygiene deep-dive page's food-prep and
-// exit-site-infection claims. PR7-9 attach these sourceIds to real medical
-// claims — currency should be re-checked at that point per R5.7 (e.g.
-// IMSS-797-16 is flagged in the explore doc as possibly superseded by a
-// newer edition).
+// exit-site-infection claims. PR7 attaches imss-797-16/medlineplus-pd to the
+// warning-signs page. PR8 adds nkf-fluid-overload + nkf-ultrafiltration for
+// the fluid-management + swelling page (content-research section 3c) —
+// currency should be re-checked at each PR per R5.7 (e.g. IMSS-797-16 is
+// flagged in the explore doc as possibly superseded by a newer edition).
 //
 // Shape: { [sourceId]: { name, org, url, published, accessed } }
 
@@ -70,6 +71,20 @@ export const sources = {
     org: 'MedlinePlus (Biblioteca Nacional de Medicina de EE. UU.)',
     url: 'https://medlineplus.gov/spanish/ency/article/007434.htm',
     published: '2024-10-28',
+    accessed: '2026-07-02'
+  },
+  'nkf-fluid-overload': {
+    name: 'Fluid Overload in a Dialysis Patient',
+    org: 'National Kidney Foundation (NKF)',
+    url: 'https://www.kidney.org/kidney-topics/fluid-overload-dialysis-patient',
+    published: null,
+    accessed: '2026-07-02'
+  },
+  'nkf-ultrafiltration': {
+    name: 'Ultrafiltration',
+    org: 'National Kidney Foundation (NKF)',
+    url: 'https://www.kidney.org/kidney-topics/ultrafiltration',
+    published: null,
     accessed: '2026-07-02'
   }
 }

--- a/src/content/topics/liquidos.js
+++ b/src/content/topics/liquidos.js
@@ -1,0 +1,151 @@
+import React from 'react'
+import { TermTooltip } from '../../components/TermTooltip'
+import { SignList } from '../../components/SignList'
+
+// liquidos: content data for the "Líquidos" (fluid management + swelling)
+// topic page (PR8), consumed by TopicPage. Every clinical claim below
+// traces to sdd/accessible-redesign/content-research section 3c
+// (fluid/swelling) or section 4 (glossary) — see the mapping table in
+// sdd/accessible-redesign/apply-progress.
+//
+// R5.5 hard rule for this page: no source states a universal fixed mL/oz
+// per-day fluid limit as appropriate for PD (NIDDK and DaVita both frame
+// the fluid goal as individualized/dietitian-set; NKF's generic "32 oz/day"
+// figure is NOT PD-specific and conflicts with that framing per the
+// research's explicit caution). No numeric fluid limit appears anywhere on
+// this page — verified by a rendered-text regex test in
+// __tests__/Liquidos.test.js.
+//
+// R5.6 hard requirement for this page (the owner's lived misconception
+// loop: fear of drinking -> severe self-restriction -> body still swells):
+// the "why swelling happens" section presents non-behavioral causes
+// (sodium intake, ultrafiltration variance/failure, membrane change over
+// years of PD) alongside behavioral guidance, and never defaults to
+// "you drank too much" as the explanation. The urgent callout directs
+// users to contact the clinic for a *change* in swelling pattern rather
+// than self-adjusting limits.
+//
+// Section order: intro -> fluid-overload warning signs (R5.1's
+// recommended-for-this-page escalation slot) -> why swelling happens
+// (misconception loop, R5.6) -> what you can do (sodium, weight,
+// individualized goal) -> citations.
+export const liquidos = {
+  title: 'Líquidos',
+  description:
+    'Qué hacer si te hinchas, por qué pasa y cómo trabajar con tu clínica tu meta de líquidos.',
+  intro: (
+    <>
+      Cuánto puedes tomar de líquido es diferente para cada persona en
+      diálisis peritoneal. Aquí encuentras qué señales de retención de
+      líquido vigilar, por qué puedes hincharte aunque tomes poco, y qué
+      puedes hacer con el apoyo de tu clínica.
+    </>
+  ),
+  sourceIds: ['niddk-nutrition-pd'],
+  sections: [
+    {
+      heading: 'Señales de retención de líquido',
+      body: (
+        <>
+          <p>
+            Si tu cuerpo está reteniendo más líquido del que debería,
+            puedes notar:
+          </p>
+          <SignList
+            items={[
+              {
+                id: 'hinchazon',
+                text: 'Hinchazón en pies, tobillos, muñecas o cara'
+              },
+              {
+                id: 'falta-aire',
+                text: 'Falta de aire o dificultad para respirar'
+              },
+              { id: 'calambres', text: 'Calambres' },
+              { id: 'dolor-cabeza', text: 'Dolor de cabeza' },
+              {
+                id: 'distension-abdominal',
+                text: 'Hinchazón (distensión) abdominal'
+              }
+            ]}
+          />
+        </>
+      ),
+      warning: {
+        level: 'urgent',
+        text:
+          'Llama a tu clínica de inmediato si notas un cambio en cómo se hincha tu cuerpo, o si te cuesta trabajo respirar. No ajustes tú mismo tus límites de líquidos — pídele a tu clínica que revise la causa.'
+      },
+      sourceIds: ['nkf-fluid-overload']
+    },
+    {
+      heading: 'Por qué te hinchas: no siempre es por tomar líquido',
+      body: (
+        <>
+          <p>
+            Es común restringirte mucho el líquido por miedo a hincharte, y
+            aun así seguir hinchándote. Esto no significa que hiciste algo
+            mal: la hinchazón puede tener otras causas que no dependen solo
+            de cuánto tomas.
+          </p>
+          <p>
+            La <TermTooltip termKey='sodio'>sal (sodio)</TermTooltip> hace
+            que tu cuerpo retenga agua y aumenta la sed. Comer con mucha sal
+            puede hacer que te hinches, aunque tomes poco líquido.
+          </p>
+          <p>
+            La diálisis peritoneal saca líquido de tu cuerpo mediante un
+            proceso llamado{' '}
+            <TermTooltip termKey='ultrafiltracion'>
+              ultrafiltración
+            </TermTooltip>
+            . La cantidad de líquido que se saca puede variar, y a veces
+            puede fallar por razones médicas — no por algo que hiciste. Esto
+            puede pasar si tienes uremia (acumulación de desechos en la
+            sangre), peritonitis, o si usas seguido soluciones con dextrosa
+            alta. Tu clínica puede revisar esto y ajustar tu tratamiento.
+          </p>
+          <p>
+            Con los años de diálisis peritoneal, la forma en que tu
+            peritoneo (la membrana donde ocurre el intercambio) filtra la
+            sal y el agua puede cambiar. Esto es algo que tu clínica revisa
+            con estudios especiales, no algo que puedas controlar con tu
+            alimentación.
+          </p>
+          <p>
+            Si notas más hinchazón de lo normal, llama a tu clínica para que
+            revise la causa. No asumas que se debe solo a lo que bebiste:
+            puede haber otras razones médicas detrás.
+          </p>
+        </>
+      ),
+      sourceIds: ['nkf-fluid-overload', 'nkf-ultrafiltration']
+    },
+    {
+      heading: 'Qué puedes hacer',
+      body: (
+        <>
+          <p>
+            La cantidad de líquido que puedes tomar cada día es diferente
+            para cada persona. Trabaja con tu nutriólogo o tu clínica para
+            definir tu meta diaria de líquidos.
+          </p>
+          <p>
+            Comer con menos sal ayuda a controlar la retención de líquido y
+            la sed. Prefiere alimentos frescos, cocina en casa y usa hierbas
+            y especias en lugar de sal.
+          </p>
+          <p>
+            Pésate todos los días, a la misma hora. Esto te ayuda, junto con
+            tu clínica, a detectar cambios en tu retención de líquido.
+          </p>
+          <p>
+            Si tienes dudas sobre tu meta de líquidos, o notas cambios en tu
+            hinchazón, pregúntale a tu clínica o a tu nutriólogo.
+          </p>
+        </>
+      ),
+      sourceIds: ['niddk-nutrition-pd', 'imss-797-16']
+    }
+  ]
+}

--- a/src/content/topics/liquidos.js
+++ b/src/content/topics/liquidos.js
@@ -25,6 +25,16 @@ import { SignList } from '../../components/SignList'
 // users to contact the clinic for a *change* in swelling pattern rather
 // than self-adjusting limits.
 //
+// R5.2 attribution note (PR8 gate review corrective pass): the
+// sodium-retention and ultrafiltration-variance/failure claims ARE stated
+// by nkf-fluid-overload/nkf-ultrafiltration and are cited to them. The
+// membrane-change (sodium-sieving, heavily simplified) sentence and the
+// closing reassurance are NOT stated by those sources — only non-allowlist
+// academic sources describe that mechanism (content-research #5086 section
+// 5, item 5) — so that content lives in its own un-sourced subsection
+// (no `sourceIds`) rather than being folded under the nkf-ultrafiltration
+// citation.
+//
 // Section order: intro -> fluid-overload warning signs (R5.1's
 // recommended-for-this-page escalation slot) -> why swelling happens
 // (misconception loop, R5.6) -> what you can do (sodium, weight,
@@ -105,12 +115,29 @@ export const liquidos = {
             sangre), peritonitis, o si usas seguido soluciones con dextrosa
             alta. Tu clínica puede revisar esto y ajustar tu tratamiento.
           </p>
+        </>
+      ),
+      sourceIds: ['nkf-fluid-overload', 'nkf-ultrafiltration']
+    },
+    {
+      // No sourceIds on this subsection, deliberately: the membrane-change
+      // sentence (heavily simplified sodium-sieving concept) and the
+      // closing reassurance are NOT claims NKF's Ultrafiltration page
+      // states — only non-allowlist academic sources describe membrane
+      // filtering changing over years (content-research #5086 section 5,
+      // item 5). Keeping this subsection un-sourced (no heading either, so
+      // it reads as a continuation of "Por qué te hinchas...") means the
+      // CitationFooter's aggregated `nkf-ultrafiltration` citation never
+      // implies NKF states this — R5.2 attribution accuracy fix, PR8 gate
+      // review corrective pass.
+      body: (
+        <>
           <p>
             Con los años de diálisis peritoneal, la forma en que tu
             peritoneo (la membrana donde ocurre el intercambio) filtra la
-            sal y el agua puede cambiar. Esto es algo que tu clínica revisa
-            con estudios especiales, no algo que puedas controlar con tu
-            alimentación.
+            sal y el agua puede cambiar. Esto no es algo que puedas
+            controlar con tu alimentación: tu clínica puede revisar cómo
+            está funcionando tu membrana con estudios especiales.
           </p>
           <p>
             Si notas más hinchazón de lo normal, llama a tu clínica para que
@@ -118,8 +145,7 @@ export const liquidos = {
             puede haber otras razones médicas detrás.
           </p>
         </>
-      ),
-      sourceIds: ['nkf-fluid-overload', 'nkf-ultrafiltration']
+      )
     },
     {
       heading: 'Qué puedes hacer',

--- a/src/pages/Liquidos.js
+++ b/src/pages/Liquidos.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Layout } from '../components/Layout'
+import { TopicPage } from '../components/TopicPage'
+import { liquidos } from '../content/topics/liquidos'
+
+// Liquidos: real content page at /alimentacion/liquidos (PR8), replacing
+// the TopicComingSoon placeholder scaffolded in PR5a. Layout provides the
+// skip-link landmark (R6.2); TopicPage composes intro -> fluid-overload
+// warning signs -> misconception loop (R5.6) -> what you can do ->
+// citations (R5.1).
+export const Liquidos = () => (
+  <Layout title={liquidos.title} description={liquidos.description}>
+    <TopicPage {...liquidos} />
+  </Layout>
+)

--- a/src/routes/RouteList.js
+++ b/src/routes/RouteList.js
@@ -9,6 +9,7 @@ import { CuidadosIndex } from '../pages/CuidadosIndex'
 import { AlimentacionIndex } from '../pages/AlimentacionIndex'
 import { Higiene } from '../pages/Higiene'
 import { SenalesAlarma } from '../pages/SenalesAlarma'
+import { Liquidos } from '../pages/Liquidos'
 import { TopicComingSoon } from '../pages/TopicComingSoon'
 import { NoMatch } from '../pages/NoMatch'
 
@@ -31,15 +32,7 @@ export const RouteList = () => (
     <Route path='/cuidados/senales-de-alarma' element={<SenalesAlarma />} />
 
     <Route path='/alimentacion' element={<AlimentacionIndex />} />
-    <Route
-      path='/alimentacion/liquidos'
-      element={
-        <TopicComingSoon
-          title='Líquidos'
-          description='Qué tomar en cuenta sobre líquidos e ingresos.'
-        />
-      }
-    />
+    <Route path='/alimentacion/liquidos' element={<Liquidos />} />
     <Route
       path='/alimentacion/nutricion'
       element={


### PR DESCRIPTION
Part of #3 (PR8 of the accessible-redesign chain — stacked on #12)

## Summary

Real content at `/alimentacion/liquidos` — born directly from the owner's lived family experience:

- **The misconception loop, addressed head-on**: fear of drinking → severe self-restriction → still swelling. The page explains that swelling is NOT automatically the patient's fault ("no significa que hiciste algo mal")
- **Three non-behavioral causes** presented with sources: sodium makes the body retain water (NKF); ultrafiltration can fail for medical reasons — uremia, peritonitis, repeated high-dextrose exchanges (NKF); and the membrane's filtering ability can change over years (kept qualitative, attributed to no source because no allowlisted source states it — "tu clínica puede revisarlo con estudios")
- **Zero fixed fluid numbers**: goals are individualized with your clinic/dietitian (NIDDK-ES framing). The banned generic "32 oz/day" figure does not appear
- **The no-number rule is enforced by a test**: a regex guard fails the suite if anyone ever adds "500 ml", "2 litros" — or "4 vasos al día" (widened after the independent review caught the gap), plus a meta-test on the regex itself
- Fluid-overload warning signs (NKF) with an urgent callout: swelling-pattern change or trouble breathing → call your clinic; never self-adjust limits
- Daily weight monitoring as self-care (IMSS-797-16); low-sodium practical guidance (NIDDK-ES)
- Glossary: sodio, ultrafiltración (conservative translation, flagged EN-source-only)

## Medical-accuracy gate (spec R5.7)

- (a) Independent claim-by-claim audit incl. a "number hunt" (zero digits in rendered content) and sentence-by-sentence blame-language scan (zero matches)
- (b) Urgent warning high on page; disclaimer on every topic page
- (c) No invented numeric thresholds — enforced by test, not just review
- (d) Owner sign-off = merging this PR

## Test plan

- [x] `npm test`: 115/115 green (16 suites)
- [x] `npm run build` passes
- [x] Independent review: PASS — 0 critical; 2 warnings (regex coverage, citation precision on the membrane claim) fixed before opening