### PR TITLE
feat(content): PD nutrition page — Mexican diet context, individualized mineral guidance

### DIFF
--- a/__tests__/Nutricion.test.js
+++ b/__tests__/Nutricion.test.js
@@ -1,0 +1,173 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { RouteList } from '../src/routes/RouteList'
+
+const renderNutricion = () =>
+  render(
+    <MemoryRouter initialEntries={['/alimentacion/nutricion']}>
+      <RouteList />
+    </MemoryRouter>
+  )
+
+// A mg/day-style numeric ceiling would violate R5.5's hard rule for this
+// page (no source states a universal mg/day threshold for sodium,
+// potassium, or phosphorus — content-research section 3d confirms this
+// explicitly for potassium/phosphorus via NKF's own individualized/
+// lab-driven framing). Source-stated portion examples like "1/2 taza" or
+// "1 rebanada delgada" are NOT numeric ceilings and must NOT trip this
+// guard — it targets mg/miligramos specifically, mirroring PR8's
+// FLUID_VOLUME_NUMBER guard pattern for its own unit.
+const MG_NUMBER = /\d+\s?(mg|miligramos?)\b/i
+
+// Meta-test: guards the guard — confirms the regex itself would catch an
+// invented mg ceiling before relying on it to scan the rendered page.
+describe('MG_NUMBER regex', () => {
+  it('matches mg/miligramos numbers, not fraction-based portion phrasing', () => {
+    expect('800 mg al día').toMatch(MG_NUMBER)
+    expect('500 miligramos por día').toMatch(MG_NUMBER)
+    expect('1/2 taza de leche').not.toMatch(MG_NUMBER)
+  })
+})
+
+// Nutricion: real content page at /alimentacion/nutricion (PR9) — R5.1,
+// R5.2, R5.4, R5.5, R5.7. Final medical-content topic page of the chain.
+describe('Nutricion page', () => {
+  it('renders under Layout at its route with the page title', () => {
+    renderNutricion()
+
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Nutrición', level: 1 })
+    ).toBeInTheDocument()
+  })
+
+  it('orders sections as protein -> minerals -> calories -> supplements', () => {
+    renderNutricion()
+
+    const headings = screen
+      .getAllByRole('heading', { level: 3 })
+      .map((heading) => heading.textContent)
+
+    const proteinIndex = headings.findIndex((text) =>
+      text.includes('proteína')
+    )
+    const sodiumIndex = headings.findIndex((text) => text.includes('sal'))
+    const potassiumIndex = headings.findIndex((text) =>
+      text.includes('Potasio')
+    )
+    const phosphorusIndex = headings.findIndex((text) =>
+      text.includes('fósforo')
+    )
+    const caloriesIndex = headings.findIndex((text) =>
+      text.includes('calorías')
+    )
+    const supplementsIndex = headings.findIndex((text) =>
+      text.includes('suplementos')
+    )
+
+    expect(proteinIndex).toBe(0)
+    expect(sodiumIndex).toBeGreaterThan(proteinIndex)
+    expect(potassiumIndex).toBeGreaterThan(sodiumIndex)
+    expect(phosphorusIndex).toBeGreaterThan(potassiumIndex)
+    expect(caloriesIndex).toBeGreaterThan(phosphorusIndex)
+    expect(supplementsIndex).toBeGreaterThan(caloriesIndex)
+  })
+
+  it('encourages high-quality protein with a source-stated portion image, without the unverified PD-vs-HD comparison', () => {
+    renderNutricion()
+
+    expect(screen.getByText(/carne, pollo, pescado y huevo/)).toBeInTheDocument()
+    expect(
+      screen.getByText(/baraja de cartas/)
+    ).toBeInTheDocument()
+
+    // R5.5/research hard rule: NIDDK's own PD nutrition page does not state
+    // a "PD needs more protein than HD" comparison — must not appear.
+    expect(screen.queryByText(/hemodiálisis/i)).not.toBeInTheDocument()
+  })
+
+  it('gives sodium guidance to cook from scratch and avoid processed/fast food', () => {
+    renderNutricion()
+
+    expect(
+      screen.getByRole('button', { name: 'sal (sodio)', hidden: true })
+    ).toBeInTheDocument()
+    expect(screen.getByText(/enlatados, empacados, congelados/)).toBeInTheDocument()
+  })
+
+  it('presents the PD-specific potassium nuance prominently: some patients may need MORE potassium', () => {
+    renderNutricion()
+
+    expect(
+      screen.getByRole('button', { name: 'potasio', hidden: true })
+    ).toBeInTheDocument()
+    expect(screen.getByText(/necesitan comer MÁS alimentos con potasio/)).toBeInTheDocument()
+    expect(screen.getByText(/plátano, la naranja, la papa y el jitomate/)).toBeInTheDocument()
+
+    // Never presented as a blanket restriction — always paired with the
+    // individualized/ask-your-clinic caveat.
+    expect(
+      screen.getAllByText(/clínica.*nutriólogo|nutriólogo.*clínica/i).length
+    ).toBeGreaterThan(0)
+  })
+
+  it('gives phosphorus guidance with source-stated portion examples and the PHOS additive label tip', () => {
+    renderNutricion()
+
+    expect(
+      screen.getByRole('button', { name: 'fósforo', hidden: true })
+    ).toBeInTheDocument()
+    expect(screen.getByText(/lácteos.*nueces.*frijoles secos/i)).toBeInTheDocument()
+    expect(screen.getByText(/media taza de leche o yogur/)).toBeInTheDocument()
+    expect(screen.getByText(/FOS.*FÓS|FÓS.*FOS/)).toBeInTheDocument()
+  })
+
+  it('frames frijoles as a portion-guidance conversation, not a food to avoid (Mexican diet note)', () => {
+    renderNutricion()
+
+    expect(
+      screen.getByText(/dieta mexicana/i)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/evita los frijoles/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/no significa que debas evitarlos/i)).toBeInTheDocument()
+  })
+
+  it('explains dialysate calories from dextrose', () => {
+    renderNutricion()
+
+    expect(screen.getByText(/dextrosa/)).toBeInTheDocument()
+    expect(screen.getByText(/calorías extra/)).toBeInTheDocument()
+  })
+
+  it('warns against OTC supplements and points to clinic-prescribed ones', () => {
+    renderNutricion()
+
+    expect(screen.getByText(/suplemento pensado para personas en diálisis/)).toBeInTheDocument()
+    expect(screen.getByText(/sin indicación médica/)).toBeInTheDocument()
+  })
+
+  it('never publishes a fixed mg/miligramos ceiling for sodium, potassium, or phosphorus (R5.5 hard rule)', () => {
+    renderNutricion()
+
+    const main = screen.getByRole('main')
+    expect(main.textContent).not.toMatch(MG_NUMBER)
+  })
+
+  it('resolves citations and always shows the clinic/nephrologist disclaimer', () => {
+    renderNutricion()
+
+    expect(
+      screen.getByRole('link', { name: /Alimentación y nutrición/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /Potassium in Your CKD Diet/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /Phosphorus and Your Diet/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/no reemplaza las indicaciones de tu clínica/)
+    ).toBeInTheDocument()
+  })
+})

--- a/__tests__/RouteList.test.js
+++ b/__tests__/RouteList.test.js
@@ -40,14 +40,6 @@ describe('RouteList', () => {
     expect(screen.getAllByText(headingText, { exact: false }).length).toBeGreaterThan(0)
   })
 
-  it.each([
-    '/alimentacion/nutricion'
-  ])('renders the topic placeholder at %s under Layout', (path) => {
-    renderAt(path)
-    expect(screen.getByRole('main')).toBeInTheDocument()
-    expect(screen.getByText(/preparando esta guía/)).toBeInTheDocument()
-  })
-
   it('renders the real Higiene content page at /cuidados/higiene under Layout', () => {
     renderAt('/cuidados/higiene')
     expect(screen.getByRole('main')).toBeInTheDocument()
@@ -71,6 +63,15 @@ describe('RouteList', () => {
     expect(screen.getByRole('main')).toBeInTheDocument()
     expect(
       screen.getByRole('heading', { name: 'Líquidos', level: 1 })
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/preparando esta guía/)).not.toBeInTheDocument()
+  })
+
+  it('renders the real Nutrición content page at /alimentacion/nutricion under Layout', () => {
+    renderAt('/alimentacion/nutricion')
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Nutrición', level: 1 })
     ).toBeInTheDocument()
     expect(screen.queryByText(/preparando esta guía/)).not.toBeInTheDocument()
   })

--- a/src/content/glossary.js
+++ b/src/content/glossary.js
@@ -3,8 +3,9 @@
 // in PR5b (heparina, peritonitis) alongside the TermTooltip component itself.
 // PR6 adds sitioSalida/cateter/clorhexidina for the hygiene deep-dive page.
 // PR7 adds efluente/hiporexia for the warning-signs + escalation page. PR8
-// adds sodio/ultrafiltracion for the fluid-management + swelling page —
-// populated further as PR9 adds its own real medical-content page.
+// adds sodio/ultrafiltracion for the fluid-management + swelling page. PR9
+// adds potasio/fosforo for the nutrition page — the final medical-content
+// page in the PR6-9 chain.
 //
 // Shape: { [termKey]: { term, plainDefinition } }
 
@@ -62,5 +63,15 @@ export const glossary = {
     term: 'Ultrafiltración',
     plainDefinition:
       'El proceso con el que se saca líquido de tu cuerpo durante un intercambio de diálisis peritoneal. Depende de la concentración de dextrosa (azúcar) del líquido de diálisis que usas.'
+  },
+  potasio: {
+    term: 'Potasio',
+    plainDefinition:
+      'Un mineral que ayuda a que tus nervios y músculos funcionen bien, incluyendo que tu corazón lata de forma constante. La diálisis peritoneal puede sacar el exceso de potasio de tu cuerpo, así que algunas personas necesitan comer más alimentos con potasio (a diferencia de lo que se indica en otras etapas de la enfermedad renal).'
+  },
+  fosforo: {
+    term: 'Fósforo',
+    plainDefinition:
+      'Un mineral que, en exceso en tu sangre, puede debilitar tus huesos (haciendo que se rompan más fácil) y causarte comezón en la piel. La diálisis peritoneal no siempre saca suficiente fósforo, así que muchas veces se necesita cuidar cuánto comes, y algunas personas necesitan medicamentos llamados quelantes de fósforo.'
   }
 }

--- a/src/content/sources.js
+++ b/src/content/sources.js
@@ -8,7 +8,9 @@
 // + medlineplus-pd for the hygiene deep-dive page's food-prep and
 // exit-site-infection claims. PR7 attaches imss-797-16/medlineplus-pd to the
 // warning-signs page. PR8 adds nkf-fluid-overload + nkf-ultrafiltration for
-// the fluid-management + swelling page (content-research section 3c) —
+// the fluid-management + swelling page (content-research section 3c). PR9
+// adds nkf-potassium + nkf-phosphorus for the nutrition page, reusing
+// niddk-nutrition-pd's URL verified in PR6 — the final medical-content PR —
 // currency should be re-checked at each PR per R5.7 (e.g. IMSS-797-16 is
 // flagged in the explore doc as possibly superseded by a newer edition).
 //
@@ -84,6 +86,20 @@ export const sources = {
     name: 'Ultrafiltration',
     org: 'National Kidney Foundation (NKF)',
     url: 'https://www.kidney.org/kidney-topics/ultrafiltration',
+    published: null,
+    accessed: '2026-07-02'
+  },
+  'nkf-potassium': {
+    name: 'Potassium in Your CKD Diet',
+    org: 'National Kidney Foundation (NKF)',
+    url: 'https://www.kidney.org/kidney-topics/potassium-your-ckd-diet',
+    published: null,
+    accessed: '2026-07-02'
+  },
+  'nkf-phosphorus': {
+    name: 'Phosphorus and Your Diet',
+    org: 'National Kidney Foundation (NKF)',
+    url: 'https://www.kidney.org/kidney-topics/phosphorus-and-your-ckd-diet',
     published: null,
     accessed: '2026-07-02'
   }

--- a/src/content/topics/nutricion.js
+++ b/src/content/topics/nutricion.js
@@ -1,0 +1,213 @@
+import React from 'react'
+import { TermTooltip } from '../../components/TermTooltip'
+
+// nutricion: content data for the "Nutrición" (PD nutrition in Mexican diet
+// context) topic page (PR9), consumed by TopicPage. Every clinical claim
+// below traces to sdd/accessible-redesign/content-research section 3d
+// (nutrition) or section 4 (glossary) — see the mapping table in
+// sdd/accessible-redesign/apply-progress. This is the final medical-content
+// PR in the chain (PR6-9).
+//
+// R5.5 hard rule for this page: no source states a universal mg/day
+// ceiling for sodium, potassium, or phosphorus — NKF's own potassium and
+// phosphorus pages explicitly frame management by lab levels/prescriber
+// guidance, not a fixed intake number (content-research section 3d, row
+// "Individualized targets confirmed..."). No mg/miligramos number appears
+// anywhere on this page — verified by a rendered-text regex test in
+// __tests__/Nutricion.test.js (mirrors PR8's FLUID_VOLUME_NUMBER guard
+// pattern for its own unit). The source-stated portion examples (deck of
+// cards, 1/2 taza, 1 rebanada, 1/4 taza) are fractions/analogies, not
+// numeric ceilings, and are explicitly allowed.
+//
+// UNVERIFIED-and-omitted per research: the common "PD needs more protein
+// than HD" comparison is NOT stated on NIDDK's own PD nutrition page
+// (content-research section 3d, row 2) — deliberately absent from this
+// page, guarded by a test asserting "hemodiálisis" never appears.
+//
+// R5.2 attribution note: the potassium and phosphorus food-category lists
+// come from NKF's general CKD-diet pages (not PD-specific), used here only
+// as a reference paired with NIDDK's PD-specific potassium nuance below —
+// never as blanket restriction advice. The frijoles/Mexican-diet note is a
+// synthesis of what both NKF lists independently state (both list beans),
+// so it stays cited to both nkf-potassium and nkf-phosphorus rather than
+// being left un-sourced.
+//
+// Glossary terms (sodio, potasio, fósforo) are wrapped with TermTooltip on
+// first use only, in reading order — R5.4.
+export const nutricion = {
+  title: 'Nutrición',
+  description:
+    'Qué comer y qué cuidar sobre proteína, sal, potasio, fósforo y calorías en diálisis peritoneal.',
+  intro: (
+    <>
+      La alimentación es una parte importante de tu cuidado en diálisis
+      peritoneal. Aquí encuentras qué debes saber sobre proteína, sal,
+      potasio, fósforo y calorías, y cuándo preguntarle a tu nutriólogo.
+    </>
+  ),
+  sourceIds: ['niddk-nutrition-pd'],
+  sections: [
+    {
+      heading: 'Come proteína de buena calidad',
+      body: (
+        <>
+          <p>
+            Elige alimentos con proteína de buena calidad, como carne, pollo,
+            pescado y huevo. Este tipo de proteína genera menos desechos
+            para que tu cuerpo elimine.
+          </p>
+          <p>
+            Una porción del tamaño de una baraja de cartas es un buen punto
+            de referencia para tu carne, pollo o pescado.
+          </p>
+        </>
+      ),
+      sourceIds: ['niddk-nutrition-pd']
+    },
+    {
+      heading: 'Cocina con menos sal',
+      body: (
+        <>
+          <p>
+            Prefiere alimentos frescos y cocina en casa. Usa hierbas y
+            especias en lugar de{' '}
+            <TermTooltip termKey='sodio'>sal (sodio)</TermTooltip> para dar
+            sabor a tu comida.
+          </p>
+          <p>
+            Evita los alimentos enlatados, empacados, congelados y de comida
+            rápida, y condimentos como la mostaza y la catsup — casi siempre
+            tienen mucha sal.
+          </p>
+        </>
+      ),
+      sourceIds: ['niddk-nutrition-pd']
+    },
+    {
+      heading: 'Potasio: pregunta a tu clínica si necesitas más o menos',
+      body: (
+        <>
+          <p>
+            La diálisis peritoneal saca el{' '}
+            <TermTooltip termKey='potasio'>potasio</TermTooltip> de tu
+            cuerpo de forma muy eficiente. Por eso, algunas personas en
+            diálisis peritoneal necesitan comer MÁS alimentos con potasio,
+            no menos — al contrario de lo que se recomienda en otras etapas
+            de la enfermedad renal.
+          </p>
+          <p>
+            Algunos alimentos con potasio son el plátano, la naranja, la
+            papa y el jitomate.
+          </p>
+          <p>
+            Esta es una referencia general de alimentos con más y con menos
+            potasio. No es una regla igual para todos:
+          </p>
+          <ul>
+            <li>
+              Con más potasio: plátano, naranja, aguacate, papa, jitomate,
+              frijol, verduras de hoja verde y nueces.
+            </li>
+            <li>
+              Con menos potasio: manzana, uvas, piña, col, elote, arroz y
+              pan.
+            </li>
+          </ul>
+          <p>
+            Tu clínica o tu nutriólogo revisa tus resultados de laboratorio
+            y te dice si necesitas comer más o menos alimentos con potasio.
+          </p>
+        </>
+      ),
+      sourceIds: ['niddk-nutrition-pd', 'nkf-potassium']
+    },
+    {
+      heading: 'Cuida cuánto fósforo comes',
+      body: (
+        <>
+          <p>
+            El <TermTooltip termKey='fosforo'>fósforo</TermTooltip> es un
+            mineral que, en exceso, puede debilitar tus huesos y causarte
+            comezón en la piel. La diálisis peritoneal no siempre saca
+            suficiente fósforo, así que muchas personas necesitan cuidar
+            cuánto comen.
+          </p>
+          <p>
+            Los lácteos (leche, yogur, queso), las nueces, los frijoles
+            secos y los refrescos de cola suelen tener mucho fósforo.
+          </p>
+          <p>
+            Por ejemplo: media taza de leche o yogur, una rebanada delgada
+            de queso, media taza de frijoles cocidos o un cuarto de taza de
+            nueces son porciones que tu nutriólogo puede ayudarte a ajustar.
+          </p>
+          <p>
+            Cuando compres alimentos empacados, revisa la lista de
+            ingredientes. Si ves una palabra que contiene &quot;FOS&quot; o
+            &quot;FÓS&quot;, ese alimento tiene fósforo agregado.
+          </p>
+          <p>
+            Tu clínica revisa tus niveles de fósforo en la sangre y te dice
+            cuánto necesitas limitar, según tus resultados.
+          </p>
+        </>
+      ),
+      sourceIds: ['niddk-nutrition-pd', 'nkf-phosphorus']
+    },
+    {
+      // No heading: reads as a visual continuation of the potassium/
+      // phosphorus sections above, since it connects a fact both of those
+      // lists independently state — the Mexican-diet-specific framing task
+      // brief calls out explicitly (frijoles on both lists -> portion
+      // guidance, not "avoid").
+      body: (
+        <p>
+          Los frijoles son un alimento muy común en la dieta mexicana y
+          aparecen tanto en la lista de alimentos con potasio como en la de
+          alimentos con fósforo. Esto no significa que debas evitarlos:
+          pregúntale a tu nutriólogo qué porción es adecuada para ti.
+        </p>
+      ),
+      sourceIds: ['nkf-potassium', 'nkf-phosphorus']
+    },
+    {
+      heading: 'La diálisis también te da calorías',
+      body: (
+        <>
+          <p>
+            El líquido que usas para tu diálisis peritoneal contiene
+            dextrosa (un tipo de azúcar) que tu cuerpo puede absorber
+            durante el intercambio. Esto le da calorías extra a tu cuerpo.
+          </p>
+          <p>
+            Por eso, algunas personas necesitan comer menos calorías en su
+            comida para no subir de peso. Tu nutriólogo puede ayudarte a
+            ajustar tu plan de alimentación.
+          </p>
+        </>
+      ),
+      sourceIds: ['niddk-nutrition-pd']
+    },
+    {
+      heading: 'Usa solo los suplementos que indique tu clínica',
+      body: (
+        <>
+          <p>
+            Si necesitas vitaminas o minerales extra, tu clínica te puede
+            recetar un suplemento pensado para personas en diálisis.
+          </p>
+          <p>
+            No tomes vitaminas o suplementos que compres tú mismo sin
+            indicación médica: algunos pueden ser dañinos para ti.
+          </p>
+          <p>
+            Un nutriólogo especializado en enfermedad renal, en tu clínica
+            de diálisis, puede ayudarte a hacer un plan de alimentación
+            hecho para ti.
+          </p>
+        </>
+      ),
+      sourceIds: ['niddk-nutrition-pd']
+    }
+  ]
+}

--- a/src/pages/Nutricion.js
+++ b/src/pages/Nutricion.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Layout } from '../components/Layout'
+import { TopicPage } from '../components/TopicPage'
+import { nutricion } from '../content/topics/nutricion'
+
+// Nutricion: real content page at /alimentacion/nutricion (PR9), replacing
+// the TopicComingSoon placeholder scaffolded in PR5a. Layout provides the
+// skip-link landmark (R6.2); TopicPage composes intro -> protein -> the
+// three minerals (sodium, potassium, phosphorus) -> calories -> supplements
+// -> citations (R5.1). Final medical-content topic page of the PR6-9 chain.
+export const Nutricion = () => (
+  <Layout title={nutricion.title} description={nutricion.description}>
+    <TopicPage {...nutricion} />
+  </Layout>
+)

--- a/src/routes/RouteList.js
+++ b/src/routes/RouteList.js
@@ -10,7 +10,7 @@ import { AlimentacionIndex } from '../pages/AlimentacionIndex'
 import { Higiene } from '../pages/Higiene'
 import { SenalesAlarma } from '../pages/SenalesAlarma'
 import { Liquidos } from '../pages/Liquidos'
-import { TopicComingSoon } from '../pages/TopicComingSoon'
+import { Nutricion } from '../pages/Nutricion'
 import { NoMatch } from '../pages/NoMatch'
 
 // Extracted from routes/index.js (which also wraps BrowserRouter + NavBar)
@@ -33,15 +33,7 @@ export const RouteList = () => (
 
     <Route path='/alimentacion' element={<AlimentacionIndex />} />
     <Route path='/alimentacion/liquidos' element={<Liquidos />} />
-    <Route
-      path='/alimentacion/nutricion'
-      element={
-        <TopicComingSoon
-          title='Nutrición'
-          description='Alimentación saludable para diálisis peritoneal.'
-        />
-      }
-    />
+    <Route path='/alimentacion/nutricion' element={<Nutricion />} />
 
     <Route path='*' element={<NoMatch />} />
   </Routes>


### PR DESCRIPTION
Part of #3 (PR9 of the accessible-redesign chain — stacked on #13; completes the four medical-content slices)

## Summary

Real content at `/alimentacion/nutricion`:

- **Protein**: high-quality protein encouraged, with NIDDK's source-stated portion image (palm/deck of cards). The "PD needs more protein than HD" comparison is ABSENT — it was unverifiable against NIDDK, so it doesn't ship (guarded by a dedicated test)
- **The potassium nuance, front and center**: PD removes potassium efficiently — some patients need MORE, not less (NIDDK-ES), opposite of generic CKD advice found online. The NKF food lists appear only as reference, explicitly captioned as "not a rule for everyone", closing with "your clinic tells you which direction applies to you"
- **Sodium**: fresh food, cook from scratch, herbs/spices, avoid packaged/fast food (NIDDK-ES)
- **Phosphorus**: food categories, NIDDK's source-stated portion examples, and the "PHOS" additive label-reading tip
- **Calories from dialysate**: the solution's dextrose adds calories (NIDDK-ES)
- **Supplements**: only kidney-specific prescribed ones; OTC may be harmful (NIDDK-ES)
- **Mexican staples** used only where the source lists support them (plátano, naranja, papa, jitomate); frijoles framed as portion-guidance — never "avoid"
- **Zero mg/day ceilings** — none exist in any source (research-confirmed); enforced by a test regex guard
- Glossary: potasio, fósforo added and linked

## Medical-accuracy gate (spec R5.7)

- (a) Independent claim-by-claim audit: every statement traces to the verified research (NIDDK-ES, NKF); food lists checked as verbatim subsets, no fabricated additions
- (b) Disclaimer renders unconditionally; individualization messaging in every mineral section
- (c) No invented numeric thresholds — mg-guard test + independent number hunt (zero mg anywhere)
- (d) Owner sign-off = merging this PR

## Test plan

- [x] `npm test`: 127/127 green (17 suites)
- [x] `npm run build` passes
- [x] Independent fresh-context review: PASS — 0 critical, 0 warnings (first perfectly clean content gate of the chain)