### PR TITLE
feat(pwa): real offline support via Workbox service worker

### DIFF
--- a/__tests__/registerServiceWorker.test.js
+++ b/__tests__/registerServiceWorker.test.js
@@ -1,0 +1,90 @@
+import { registerServiceWorker } from '../src/utils/registerServiceWorker'
+
+const buildNavigator = ({ withServiceWorker = true, register } = {}) => {
+  if (!withServiceWorker) {
+    return {}
+  }
+
+  return {
+    serviceWorker: {
+      register: register || jest.fn().mockResolvedValue({ scope: '/' })
+    }
+  }
+}
+
+const buildWindow = () => ({
+  addEventListener: jest.fn()
+})
+
+describe('registerServiceWorker', () => {
+  it('does nothing outside production', () => {
+    const windowRef = buildWindow()
+    const navigatorRef = buildNavigator()
+
+    const result = registerServiceWorker({
+      nodeEnv: 'development',
+      navigatorRef,
+      windowRef
+    })
+
+    expect(result).toBe(false)
+    expect(windowRef.addEventListener).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the browser has no serviceWorker support', () => {
+    const windowRef = buildWindow()
+    const navigatorRef = buildNavigator({ withServiceWorker: false })
+
+    const result = registerServiceWorker({
+      nodeEnv: 'production',
+      navigatorRef,
+      windowRef
+    })
+
+    expect(result).toBe(false)
+    expect(windowRef.addEventListener).not.toHaveBeenCalled()
+  })
+
+  it('registers the service worker on window load in production', () => {
+    const windowRef = buildWindow()
+    const register = jest.fn().mockResolvedValue({ scope: '/' })
+    const navigatorRef = buildNavigator({ register })
+
+    const result = registerServiceWorker({
+      nodeEnv: 'production',
+      navigatorRef,
+      windowRef
+    })
+
+    expect(result).toBe(true)
+    expect(windowRef.addEventListener).toHaveBeenCalledWith(
+      'load',
+      expect.any(Function)
+    )
+
+    const loadHandler = windowRef.addEventListener.mock.calls[0][1]
+    loadHandler()
+
+    expect(register).toHaveBeenCalledWith('/service-worker.js')
+  })
+
+  it('does not throw when registration fails', async () => {
+    const windowRef = buildWindow()
+    const registrationError = new Error('registration failed')
+    const register = jest.fn().mockRejectedValue(registrationError)
+    const navigatorRef = buildNavigator({ register })
+    const onError = jest.fn()
+
+    registerServiceWorker({
+      nodeEnv: 'production',
+      navigatorRef,
+      windowRef,
+      onError
+    })
+
+    const loadHandler = windowRef.addEventListener.mock.calls[0][1]
+    await loadHandler()
+
+    expect(onError).toHaveBeenCalledWith(registrationError)
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
                 "@testing-library/user-event": "^14.6.1",
                 "babel-jest": "^30.4.1",
                 "babel-loader": "^9.1.3",
+                "copy-webpack-plugin": "^14.0.0",
                 "css-loader": "^6.10.0",
                 "file-loader": "6.2.0",
                 "html-loader": "^4.2.0",
@@ -49,7 +50,8 @@
                 "url-loader": "4.1.1",
                 "webpack": "^5.95.0",
                 "webpack-cli": "^5.1.4",
-                "webpack-dev-server": "^5.1.0"
+                "webpack-dev-server": "^5.1.0",
+                "workbox-webpack-plugin": "^7.4.1"
             }
         },
         "node_modules/@adobe/css-tools": {
@@ -2915,9 +2917,9 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-            "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true,
             "license": "MIT"
         },
@@ -3165,6 +3167,499 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@rollup/plugin-babel": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.1.0.tgz",
+            "integrity": "sha512-dFZNuFD2YRcoomP4oYf+DvQNSUA9ih+A3vUqopQx5EdtPGo3WBnQcI/S8pwpz91UsGfL0HsMSOlaMld8HrbubA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.18.6",
+                "@rollup/pluginutils": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0",
+                "@types/babel__core": "^7.1.9",
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/babel__core": {
+                    "optional": true
+                },
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-node-resolve": {
+            "version": "16.0.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+            "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "@types/resolve": "1.20.2",
+                "deepmerge": "^4.2.2",
+                "is-module": "^1.0.0",
+                "resolve": "^1.22.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.78.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+            "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "magic-string": "^0.30.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-terser": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+            "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "serialize-javascript": "^7.0.3",
+                "smob": "^1.0.0",
+                "terser": "^5.17.4"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-terser/node_modules/serialize-javascript": {
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+            "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@rollup/pluginutils": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+            "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+            "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+            "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+            "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+            "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+            "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+            "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+            "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+            "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+            "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+            "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+            "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+            "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+            "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+            "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+            "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+            "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+            "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+            "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+            "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+            "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+            "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+            "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+            "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+            "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+            "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@rtsao/scc": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3296,6 +3791,22 @@
                 "@testing-library/dom": ">=7.21.4"
             }
         },
+        "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
+            "version": "3.0.0-pre1",
+            "resolved": "https://registry.npmjs.org/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz",
+            "integrity": "sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "ejs": "^3.1.10",
+                "json5": "^2.2.3",
+                "magic-string": "^0.30.21",
+                "string.prototype.matchall": "^4.0.12"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/@tybys/wasm-util": {
             "version": "0.10.3",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -3425,9 +3936,9 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
             "dev": true,
             "license": "MIT"
         },
@@ -3575,6 +4086,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/resolve": {
+            "version": "1.20.2",
+            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+            "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/retry": {
             "version": "0.12.2",
             "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
@@ -3642,6 +4160,13 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
             "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
             "dev": true,
             "license": "MIT"
         },
@@ -4599,6 +5124,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/async": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+            "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/async-function": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -4607,6 +5139,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 4.0.0"
             }
         },
         "node_modules/available-typed-arrays": {
@@ -5296,6 +5838,16 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/common-tags": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+            "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
         "node_modules/compressible": {
             "version": "2.0.18",
             "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -5422,6 +5974,53 @@
                 "url": "https://github.com/sponsors/mesqueeb"
             }
         },
+        "node_modules/copy-webpack-plugin": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-14.0.0.tgz",
+            "integrity": "sha512-3JLW90aBGeaTLpM7mYQKpnVdgsUZRExY55giiZgLuX/xTQRUs1dOCwbBnWnvY6Q6rfZoXMNwzOQJCSZPppfqXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "glob-parent": "^6.0.1",
+                "normalize-path": "^3.0.0",
+                "schema-utils": "^4.2.0",
+                "serialize-javascript": "^7.0.3",
+                "tinyglobby": "^0.2.12"
+            },
+            "engines": {
+                "node": ">= 20.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.1.0"
+            }
+        },
+        "node_modules/copy-webpack-plugin/node_modules/glob-parent": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/copy-webpack-plugin/node_modules/serialize-javascript": {
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+            "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/core-js-compat": {
             "version": "3.44.0",
             "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.44.0.tgz",
@@ -5483,6 +6082,16 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/crypto-random-string": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+            "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/css-color-keywords": {
@@ -6042,6 +6651,22 @@
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/ejs": {
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+            "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "jake": "^10.8.5"
+            },
+            "bin": {
+                "ejs": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/electron-to-chromium": {
             "version": "1.5.187",
@@ -7021,6 +7646,13 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -7029,6 +7661,19 @@
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/eta": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/eta/-/eta-4.6.0.tgz",
+            "integrity": "sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/bgub/eta?sponsor=1"
             }
         },
         "node_modules/etag": {
@@ -7354,6 +7999,39 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/filelist": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+            "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "minimatch": "^5.0.1"
+            }
+        },
+        "node_modules/filelist/node_modules/brace-expansion": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/filelist/node_modules/minimatch": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/fill-range": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -7657,6 +8335,22 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -7764,6 +8458,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/get-own-enumerable-property-symbols": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+            "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/get-package-type": {
             "version": "0.1.0",
@@ -8402,6 +9103,13 @@
                 "postcss": "^8.1.0"
             }
         },
+        "node_modules/idb": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+            "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -8831,6 +9539,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+            "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/is-negative-zero": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -8882,6 +9597,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/is-path-inside": {
@@ -8944,6 +9669,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-regexp": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+            "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/is-set": {
@@ -9248,6 +9983,24 @@
             },
             "optionalDependencies": {
                 "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/jake": {
+            "version": "10.9.4",
+            "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+            "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "async": "^3.2.6",
+                "filelist": "^1.0.4",
+                "picocolors": "^1.1.1"
+            },
+            "bin": {
+                "jake": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/jest": {
@@ -10525,6 +11278,29 @@
                 "node": ">=6"
             }
         },
+        "node_modules/jsonfile": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+            "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/jsonpointer": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+            "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/jsx-ast-utils": {
             "version": "3.3.5",
             "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -10768,6 +11544,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/lodash.sortby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -10809,6 +11592,16 @@
             "peer": true,
             "bin": {
                 "lz-string": "bin/bin.js"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
         "node_modules/make-dir": {
@@ -12046,6 +12839,19 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/pretty-bytes": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+            "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/pretty-error": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
@@ -12678,6 +13484,51 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/rollup": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+            "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "1.0.9"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.62.2",
+                "@rollup/rollup-android-arm64": "4.62.2",
+                "@rollup/rollup-darwin-arm64": "4.62.2",
+                "@rollup/rollup-darwin-x64": "4.62.2",
+                "@rollup/rollup-freebsd-arm64": "4.62.2",
+                "@rollup/rollup-freebsd-x64": "4.62.2",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+                "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+                "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+                "@rollup/rollup-linux-arm64-musl": "4.62.2",
+                "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+                "@rollup/rollup-linux-loong64-musl": "4.62.2",
+                "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+                "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+                "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+                "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+                "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+                "@rollup/rollup-linux-x64-gnu": "4.62.2",
+                "@rollup/rollup-linux-x64-musl": "4.62.2",
+                "@rollup/rollup-openbsd-x64": "4.62.2",
+                "@rollup/rollup-openharmony-arm64": "4.62.2",
+                "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+                "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+                "@rollup/rollup-win32-x64-gnu": "4.62.2",
+                "@rollup/rollup-win32-x64-msvc": "4.62.2",
+                "fsevents": "~2.3.2"
             }
         },
         "node_modules/rrweb-cssom": {
@@ -13355,6 +14206,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/smob": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.2.tgz",
+            "integrity": "sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/sockjs": {
             "version": "0.3.24",
             "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -13366,6 +14227,13 @@
                 "uuid": "^8.3.2",
                 "websocket-driver": "^0.7.4"
             }
+        },
+        "node_modules/source-list-map": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
+            "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/source-map": {
             "version": "0.6.1",
@@ -13704,6 +14572,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/stringify-object": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+            "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "get-own-enumerable-property-symbols": "^3.0.0",
+                "is-obj": "^1.0.1",
+                "is-regexp": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -13739,6 +14622,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/strip-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
+            "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/strip-final-newline": {
@@ -13992,6 +14885,48 @@
                 "node": ">=6"
             }
         },
+        "node_modules/temp-dir": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+            "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/tempy": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.6.0.tgz",
+            "integrity": "sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-stream": "^2.0.0",
+                "temp-dir": "^2.0.0",
+                "type-fest": "^0.16.0",
+                "unique-string": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/tempy/node_modules/type-fest": {
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+            "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/terser": {
             "version": "5.43.1",
             "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
@@ -14094,6 +15029,54 @@
             "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/tldts": {
             "version": "6.1.86",
@@ -14419,6 +15402,29 @@
                 "node": ">=4"
             }
         },
+        "node_modules/unique-string": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+            "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "crypto-random-string": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
         "node_modules/unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -14465,6 +15471,17 @@
                 "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
                 "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
                 "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
+            }
+        },
+        "node_modules/upath": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+            "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4",
+                "yarn": "*"
             }
         },
         "node_modules/update-browserslist-db": {
@@ -14942,6 +15959,17 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/webpack-sources": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+            "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "source-list-map": "^2.0.0",
+                "source-map": "~0.6.1"
+            }
+        },
         "node_modules/webpack/node_modules/acorn-import-phases": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
@@ -15161,6 +16189,434 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/workbox-background-sync": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.4.1.tgz",
+            "integrity": "sha512-HhT7KE8tOWDm02wRNshXUnUPofMlhenF2DBdUnDPOubhizzPeItkYTmAB6td1Z2cjYPa98vzEiPLEuzn5hN66g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "idb": "^7.0.1",
+                "workbox-core": "7.4.1"
+            }
+        },
+        "node_modules/workbox-broadcast-update": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.4.1.tgz",
+            "integrity": "sha512-uAlgslKLvbQY+suirIdnBCSYrcgBhjp81Nj4l1lj/Jmj0MJO2CJERnCJjT0GFVwmReV0N+zs78K6gqd5gr9/+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-core": "7.4.1"
+            }
+        },
+        "node_modules/workbox-build": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-7.4.1.tgz",
+            "integrity": "sha512-SDhxIvEAde9Gy/5w4Yo1Jh/M49Z0qE3q0oteyE8zGq0DScxFqVBcCtIXFuLtmtxRQZCMbf0prco4VyEu3KBQuw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@apideck/better-ajv-errors": "^0.3.1",
+                "@babel/core": "^7.24.4",
+                "@babel/preset-env": "^7.11.0",
+                "@babel/runtime": "^7.11.2",
+                "@rollup/plugin-babel": "^6.1.0",
+                "@rollup/plugin-node-resolve": "^16.0.3",
+                "@rollup/plugin-replace": "^6.0.3",
+                "@rollup/plugin-terser": "^1.0.0",
+                "@trickfilm400/rollup-plugin-off-main-thread": "^3.0.0-pre1",
+                "ajv": "^8.6.0",
+                "common-tags": "^1.8.0",
+                "eta": "^4.5.1",
+                "fast-json-stable-stringify": "^2.1.0",
+                "fs-extra": "^9.0.1",
+                "glob": "^11.0.1",
+                "pretty-bytes": "^5.3.0",
+                "rollup": "^4.53.3",
+                "source-map": "^0.8.0-beta.0",
+                "stringify-object": "^3.3.0",
+                "strip-comments": "^2.0.1",
+                "tempy": "^0.6.0",
+                "upath": "^1.2.0",
+                "workbox-background-sync": "7.4.1",
+                "workbox-broadcast-update": "7.4.1",
+                "workbox-cacheable-response": "7.4.1",
+                "workbox-core": "7.4.1",
+                "workbox-expiration": "7.4.1",
+                "workbox-google-analytics": "7.4.1",
+                "workbox-navigation-preload": "7.4.1",
+                "workbox-precaching": "7.4.1",
+                "workbox-range-requests": "7.4.1",
+                "workbox-recipes": "7.4.1",
+                "workbox-routing": "7.4.1",
+                "workbox-strategies": "7.4.1",
+                "workbox-streams": "7.4.1",
+                "workbox-sw": "7.4.1",
+                "workbox-window": "7.4.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/workbox-build/node_modules/@apideck/better-ajv-errors": {
+            "version": "0.3.7",
+            "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.7.tgz",
+            "integrity": "sha512-TajUJwGWbDwkCx/CZi7tRE8PVB7simCvKJfHUsSdvps+aTM/PDPP4gkLmKnc+x3CE//y9i/nj74GqdL/hwk7Iw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "jsonpointer": "^5.0.1",
+                "leven": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "ajv": ">=8"
+            }
+        },
+        "node_modules/workbox-build/node_modules/@isaacs/cliui": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+            "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/workbox-build/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/workbox-build/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/workbox-build/node_modules/brace-expansion": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/workbox-build/node_modules/glob": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+            "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "foreground-child": "^3.3.1",
+                "jackspeak": "^4.1.1",
+                "minimatch": "^10.1.1",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^2.0.0"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/workbox-build/node_modules/jackspeak": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+            "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^9.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/workbox-build/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/workbox-build/node_modules/lru-cache": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/workbox-build/node_modules/minimatch": {
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.5"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/workbox-build/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/workbox-build/node_modules/source-map": {
+            "version": "0.8.0-beta.0",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+            "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+            "deprecated": "The work that was done in this beta branch won't be included in future versions",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "whatwg-url": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/workbox-build/node_modules/tr46": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+            "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/workbox-build/node_modules/webidl-conversions": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+            "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+            "dev": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/workbox-build/node_modules/whatwg-url": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+            "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^1.0.1",
+                "webidl-conversions": "^4.0.2"
+            }
+        },
+        "node_modules/workbox-cacheable-response": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.4.1.tgz",
+            "integrity": "sha512-8xaFoJdDc2OjrlbbL3gEeBO1WKcMwRqwLRupgqahYXu75yXajPLuwrbXMrIGZuWYXrQwk0xDjOxZ/ujCy/oJYw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-core": "7.4.1"
+            }
+        },
+        "node_modules/workbox-core": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.4.1.tgz",
+            "integrity": "sha512-DT+vu46eh/2vRsSHTY4Xmc32Z1rr9PRlQUXr1Dx30ZuXRWwOsvZgGgcwxcasubQLQmbTNYZjv44LkBAQ4tT5tQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/workbox-expiration": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.4.1.tgz",
+            "integrity": "sha512-lRKUF7b+OGbeXkQk1s6MHXOa3d7Xxf7Of31W6c6hCfipfIyrtdWZ89stq21AHZMaoG7VNFoHply4Ox+rU31TWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "idb": "^7.0.1",
+                "workbox-core": "7.4.1"
+            }
+        },
+        "node_modules/workbox-google-analytics": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-7.4.1.tgz",
+            "integrity": "sha512-Mks1JwLEt++ZAkF6sS1OpSh9RtAMIsiDgRpK+codiHGIPXeaUOgi4cPc3GFadUl8V5QPeypEk8Oxgl3HlwVzHw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-background-sync": "7.4.1",
+                "workbox-core": "7.4.1",
+                "workbox-routing": "7.4.1",
+                "workbox-strategies": "7.4.1"
+            }
+        },
+        "node_modules/workbox-navigation-preload": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-7.4.1.tgz",
+            "integrity": "sha512-C4KVsjPcYKJOhr631AxR9XoG2rLF3QiTk5aMv36MXOjtWvm8axwNFAtKUPGsWUwLXXAMgYM1En7fsvndaXeXRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-core": "7.4.1"
+            }
+        },
+        "node_modules/workbox-precaching": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-7.4.1.tgz",
+            "integrity": "sha512-cdr/9qByww7yzEp7zg/qI4ukUrrNjQLgN+ONQRpjy/VqGQXwkgHwr00KksGJK8v0VifwDXBb8a4cWNZH71jn3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-core": "7.4.1",
+                "workbox-routing": "7.4.1",
+                "workbox-strategies": "7.4.1"
+            }
+        },
+        "node_modules/workbox-range-requests": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-7.4.1.tgz",
+            "integrity": "sha512-7i2oxAUE82gHdAJBCAQ04JzNOdRPqzuOzGfoUyJpFSmeqBNYGPrAH8GPoPjUQTfp+NycwrD2H68VtuF8qxv0vQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-core": "7.4.1"
+            }
+        },
+        "node_modules/workbox-recipes": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-7.4.1.tgz",
+            "integrity": "sha512-gnbVfmV4/TtmQaM4x9AtuXhcdstJsep3XMVeztOrQVPT+R6+6DeBjGTCQ7fFCXm+4GEHUA5VEBTyi5+4gWGeog==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-cacheable-response": "7.4.1",
+                "workbox-core": "7.4.1",
+                "workbox-expiration": "7.4.1",
+                "workbox-precaching": "7.4.1",
+                "workbox-routing": "7.4.1",
+                "workbox-strategies": "7.4.1"
+            }
+        },
+        "node_modules/workbox-routing": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.4.1.tgz",
+            "integrity": "sha512-yubJGErZOusuidAenaL5ypfhQOa7urxP/f8E0ws7FPb4039RiWXUWBAyUkmUoOL/BcQGen3h0J8872d51IYxtA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-core": "7.4.1"
+            }
+        },
+        "node_modules/workbox-strategies": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.4.1.tgz",
+            "integrity": "sha512-GZxpaw9NbmOelj7667uZ2kpk5BFpOGbO4X0qjwh5ls8XQ8C+Lha5LQchTiUzsTFSS+NlUpftYAyOVXvQUrcqOQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-core": "7.4.1"
+            }
+        },
+        "node_modules/workbox-streams": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-7.4.1.tgz",
+            "integrity": "sha512-HWWtraKUbJknd9kgqGcpQ3G114HOPYvqs8HaJMDs2ebLNAimDkVDaWfAXE6Ybl+m8U6KsCE6pWyLYuigWmnAXw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-core": "7.4.1",
+                "workbox-routing": "7.4.1"
+            }
+        },
+        "node_modules/workbox-sw": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.4.1.tgz",
+            "integrity": "sha512-fez5f2DUlDJWTFYkCWQpY10N8gtztd849NswCbVFk0QlcSM4HT5A8x4g4ii650yem4I8tHY0R7JZahwp3ltIPw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/workbox-webpack-plugin": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/workbox-webpack-plugin/-/workbox-webpack-plugin-7.4.1.tgz",
+            "integrity": "sha512-Gf8th+7jJbzjABMeZxJDDeKyxmHcsWjXos4vQQRD+6KIk0vtv1k9c6Yf9aletamS3liN3HGojzxbrXuNc+wu4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-json-stable-stringify": "^2.1.0",
+                "pretty-bytes": "^5.4.1",
+                "upath": "^1.2.0",
+                "webpack-sources": "^1.4.3",
+                "workbox-build": "7.4.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "webpack": "^4.4.0 || ^5.91.0"
+            }
+        },
+        "node_modules/workbox-window": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.4.1.tgz",
+            "integrity": "sha512-notZDH2u8VXaqyuD7xaqIfEFi6SRM4SUSd7ewe9PDsVqADuepxX2ZMY3uvuZGxzY5ZOsGC/vD3A/3smFtJt4/A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/trusted-types": "^2.0.2",
+                "workbox-core": "7.4.1"
             }
         },
         "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "@testing-library/user-event": "^14.6.1",
         "babel-jest": "^30.4.1",
         "babel-loader": "^9.1.3",
+        "copy-webpack-plugin": "^14.0.0",
         "css-loader": "^6.10.0",
         "file-loader": "6.2.0",
         "html-loader": "^4.2.0",
@@ -43,7 +44,8 @@
         "url-loader": "4.1.1",
         "webpack": "^5.95.0",
         "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^5.1.0"
+        "webpack-dev-server": "^5.1.0",
+        "workbox-webpack-plugin": "^7.4.1"
     },
     "dependencies": {
         "@babel/runtime": "^7.24.0",

--- a/public/index.html
+++ b/public/index.html
@@ -159,9 +159,9 @@
                 document.body.classList.add("loaded");
             });
 
-            // Nota: el registro del Service Worker se removió porque no existe
-            // un service-worker.js real (fallaba en cada carga). Se reintroducirá
-            // junto con una implementación real (ver backlog PR10+).
+            // Nota: el registro real del Service Worker vive en src/index.js
+            // (registerServiceWorker), gateado a producción, y consume el
+            // service-worker.js generado por Workbox (ver webpack.config.js).
         </script>
     </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,12 @@
-import React from "react";
-import { createRoot } from "react-dom/client";
-import { App } from "./components/App";
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { App } from './components/App'
+import { registerServiceWorker } from './utils/registerServiceWorker'
 
-const container = document.getElementById("app");
-const root = createRoot(container);
-root.render(<App />);
+const container = document.getElementById('app')
+const root = createRoot(container)
+root.render(<App />)
+
+// Real offline support (production only, see webpack.config.js for the
+// Workbox precache/runtime-caching strategy).
+registerServiceWorker()

--- a/src/utils/registerServiceWorker.js
+++ b/src/utils/registerServiceWorker.js
@@ -1,0 +1,31 @@
+// registerServiceWorker: gates the real service-worker registration
+// (Workbox-generated `service-worker.js`, see webpack.config.js) so it only
+// runs in a production build with browser support. No service worker runs
+// in development — hot reload and the dev server would otherwise fight
+// stale caches.
+//
+// Dependencies are injectable (nodeEnv/navigatorRef/windowRef/onError) so
+// the gating logic is unit-testable in jsdom without faking real browser
+// service-worker behavior.
+
+export function registerServiceWorker ({
+  nodeEnv = process.env.NODE_ENV,
+  navigatorRef = typeof navigator !== 'undefined' ? navigator : undefined,
+  windowRef = typeof window !== 'undefined' ? window : undefined,
+  onError = (error) => console.error('Service worker registration failed:', error)
+} = {}) {
+  const supportsServiceWorker =
+    Boolean(navigatorRef) && 'serviceWorker' in navigatorRef
+
+  if (nodeEnv !== 'production' || !supportsServiceWorker || !windowRef) {
+    return false
+  }
+
+  windowRef.addEventListener('load', () => {
+    return navigatorRef.serviceWorker
+      .register('/service-worker.js')
+      .catch(onError)
+  })
+
+  return true
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,94 +1,13 @@
 const path = require('path')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const MiniCSSExtractPlugin = require('mini-css-extract-plugin')
+const CopyWebpackPlugin = require('copy-webpack-plugin')
+const { GenerateSW } = require('workbox-webpack-plugin')
 
-module.exports = {
-  entry: {
-    entry: './src/index.js'
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: '[name].[contenthash].js',
-    clean: true
-  },
-  devServer: {
-    historyApiFallback: true
-  },
-  resolve: {
-    extensions: ['.js', '.jsx']
-  },
-  module: {
-    rules: [
-      {
-        test: /\.css$/,
-        use: [
-          {
-            loader: MiniCSSExtractPlugin.loader
-          },
-          {
-            loader: 'css-loader',
-            options: {
-              importLoaders: 1
-            }
-          },
-          'postcss-loader'
-        ]
-      },
-      {
-        test: /\.scss$/,
-        use: [
-          {
-            loader: MiniCSSExtractPlugin.loader
-          },
-          'css-loader',
-          'sass-loader'
-        ]
-      },
-      {
-        test: /\.less$/,
-        use: [
-          {
-            loader: MiniCSSExtractPlugin.loader
-          },
-          'css-loader',
-          'less-loader'
-        ]
-      },
-      {
-        test: /\.styl$/,
-        use: [
-          {
-            loader: MiniCSSExtractPlugin.loader
-          },
-          'css-loader',
-          'stylus-loader'
-        ]
-      },
-      {
-        test: /\.(js|jsx)$/,
-        use: 'babel-loader',
-        exclude: /node_modules/
-      },
-      {
-        test: /\.html$/,
-        use: [
-          {
-            loader: 'html-loader'
-          }
-        ]
-      },
-      {
-        test: /\.jpg|png|gif|woff|eot|ttf|svg|mp4|webm$/,
-        use: {
-          loader: 'url-loader',
-          options: {
-            limit: 90000
-          }
-        }
-      }
-    ]
-  },
-  plugins: [
+module.exports = (env, argv) => {
+  const isProduction = argv.mode === 'production'
+
+  const plugins = [
     new HtmlWebpackPlugin({
       template: 'public/index.html',
       filename: 'index.html',
@@ -96,17 +15,211 @@ module.exports = {
     }),
     new MiniCSSExtractPlugin({
       filename: 'css/[name].css'
+    }),
+    // Copies the PWA manifest + icon set (referenced from public/index.html
+    // and public/manifest.json) into dist. These were never emitted before
+    // this PR — the manifest link and touch icons silently 404'd in
+    // production. Skipped: index.html (handled by HtmlWebpackPlugin above)
+    // and favicon.ico (already emitted via the `favicon` option above).
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: 'public',
+          to: '.',
+          globOptions: {
+            ignore: ['**/index.html', '**/favicon.ico']
+          }
+        }
+      ]
     })
-  ],
-  optimization: {
-    moduleIds: 'deterministic',
-    runtimeChunk: 'single',
-    splitChunks: {
-      cacheGroups: {
-        vendor: {
-          test: /[\\/]node_modules[\\/]/,
-          name: 'vendors',
-          chunks: 'all'
+  ]
+
+  if (isProduction) {
+    plugins.push(
+      // Real offline support. GenerateSW must run last so it sees every
+      // asset emitted by the plugins above (including the copied manifest
+      // icons) when building the precache manifest.
+      //
+      // Caching strategy:
+      // - Precache: JS/CSS bundles + index.html + manifest/icons (the app
+      //   shell). Poster images are small enough to be inlined as base64 by
+      //   url-loader (see the asset rule below, limit: 90000) so they ride
+      //   along inside the precached JS — no separate poster entries needed.
+      // - Runtime, CacheFirst: step videos (`.webm`). These are large
+      //   (hundreds of KB to a few MB each) and excluded from precache so
+      //   installing the app doesn't force-download every video up front;
+      //   each video is cached the first time it's actually watched, with a
+      //   capped entry count + expiration so storage doesn't grow unbounded
+      //   on older/low-storage devices. Range requests are enabled so video
+      //   seeking works against the cache.
+      // - Runtime, stale-while-revalidate: Google Fonts stylesheet (served
+      //   fresh from cache immediately, revalidated in the background).
+      // - Runtime, CacheFirst: Google Fonts webfont files (rarely change,
+      //   long-lived cache is safe).
+      // - navigateFallback: any SPA navigation offline falls back to the
+      //   precached index.html, EXCEPT requests for the service worker
+      //   itself and any request with a file extension (static assets),
+      //   which must resolve to the real asset, never the HTML shell.
+      new GenerateSW({
+        swDest: 'service-worker.js',
+        clientsClaim: true,
+        skipWaiting: true,
+        cleanupOutdatedCaches: true,
+        // entry.[contenthash].js grows past the 2 MiB default cap because
+        // small poster images are inlined into it as base64; raise the cap
+        // instead of excluding the app's own entry bundle from precache.
+        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
+        exclude: [
+          /\.map$/,
+          /^manifest.*\.js$/,
+          /\.webm$/,
+          /\.LICENSE\.txt$/
+        ],
+        navigateFallback: '/index.html',
+        navigateFallbackDenylist: [
+          /^\/service-worker\.js$/,
+          // any request ending in a file extension is a static asset, not
+          // a SPA route — never serve it the HTML fallback
+          /\.[^/?]+$/
+        ],
+        runtimeCaching: [
+          {
+            urlPattern: ({ url }) => url.origin === 'https://fonts.googleapis.com',
+            handler: 'StaleWhileRevalidate',
+            options: {
+              cacheName: 'google-fonts-stylesheets'
+            }
+          },
+          {
+            urlPattern: ({ url }) => url.origin === 'https://fonts.gstatic.com',
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'google-fonts-webfonts',
+              cacheableResponse: { statuses: [0, 200] },
+              expiration: {
+                maxEntries: 30,
+                maxAgeSeconds: 60 * 60 * 24 * 365
+              }
+            }
+          },
+          {
+            urlPattern: /\.webm$/,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'step-videos',
+              cacheableResponse: { statuses: [0, 200] },
+              expiration: {
+                maxEntries: 20,
+                maxAgeSeconds: 60 * 60 * 24 * 30
+              },
+              rangeRequests: true
+            }
+          }
+        ]
+      })
+    )
+  }
+
+  return {
+    entry: {
+      entry: './src/index.js'
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: '[name].[contenthash].js',
+      clean: true
+    },
+    devServer: {
+      historyApiFallback: true,
+      static: {
+        directory: path.resolve(__dirname, 'public')
+      }
+    },
+    resolve: {
+      extensions: ['.js', '.jsx']
+    },
+    module: {
+      rules: [
+        {
+          test: /\.css$/,
+          use: [
+            {
+              loader: MiniCSSExtractPlugin.loader
+            },
+            {
+              loader: 'css-loader',
+              options: {
+                importLoaders: 1
+              }
+            },
+            'postcss-loader'
+          ]
+        },
+        {
+          test: /\.scss$/,
+          use: [
+            {
+              loader: MiniCSSExtractPlugin.loader
+            },
+            'css-loader',
+            'sass-loader'
+          ]
+        },
+        {
+          test: /\.less$/,
+          use: [
+            {
+              loader: MiniCSSExtractPlugin.loader
+            },
+            'css-loader',
+            'less-loader'
+          ]
+        },
+        {
+          test: /\.styl$/,
+          use: [
+            {
+              loader: MiniCSSExtractPlugin.loader
+            },
+            'css-loader',
+            'stylus-loader'
+          ]
+        },
+        {
+          test: /\.(js|jsx)$/,
+          use: 'babel-loader',
+          exclude: /node_modules/
+        },
+        {
+          test: /\.html$/,
+          use: [
+            {
+              loader: 'html-loader'
+            }
+          ]
+        },
+        {
+          test: /\.jpg|png|gif|woff|eot|ttf|svg|mp4|webm$/,
+          use: {
+            loader: 'url-loader',
+            options: {
+              limit: 90000
+            }
+          }
+        }
+      ]
+    },
+    plugins,
+    optimization: {
+      moduleIds: 'deterministic',
+      runtimeChunk: 'single',
+      splitChunks: {
+        cacheGroups: {
+          vendor: {
+            test: /[\\/]node_modules[\\/]/,
+            name: 'vendors',
+            chunks: 'all'
+          }
         }
       }
     }


### PR DESCRIPTION
Part of #3 (PR10 of the accessible-redesign chain — stacked on #14; optional slice 1 of 2)

## Summary

The guide now works **without internet** — gold for caregivers at a clinic with no signal:

- Workbox GenerateSW wired into the webpack build (production only; dev builds emit no SW)
- **Precache**: full app shell — 34 entries, 2.69 MB (JS, index.html, manifest, all icons). Zero `.webm` files precached
- **Videos**: runtime CacheFirst with `maxEntries: 20` + 30-day expiration + range-request support — cached as watched, storage never balloons on old phones
- Google Fonts: stale-while-revalidate; SPA navigateFallback with a denylist verified not to swallow static assets
- Registration extracted to a tested helper, gated to production
- **Bonus find**: `manifest.json` and ALL PWA icons were never copied to `dist/` — every prior production deploy 404'd them silently. Fixed with copy-webpack-plugin (independently confirmed by building the base branch)

## Accepted decision (flagged by the independent review)

`skipWaiting` + `clientsClaim` are enabled (standard Workbox pattern): new versions take control immediately, with a theoretical stale-window on already-open tabs. Acceptable for this content app; an update-notification UI is a possible future enhancement.

## Test plan

- [x] `npm test`: 131/131 green (18 suites)
- [x] `npm run build` emits service-worker.js — reviewer inspected the generated file directly (precache manifest, runtime routes, fallback denylist)
- [x] `webpack --mode development` verified to emit no SW
- [x] Independent fresh-context review: PASS — 0 critical