### PR TITLE
feat(health-log): versioned on-device storage utility for the daily log

### DIFF
--- a/__tests__/healthLog.test.js
+++ b/__tests__/healthLog.test.js
@@ -1,0 +1,202 @@
+import {
+  loadEntries,
+  saveEntry,
+  clearAll,
+  todayISO,
+  computeDelta,
+  MAX_ENTRIES,
+  STORAGE_KEY
+} from '../src/utils/healthLog'
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+describe('healthLog storage', () => {
+  it('returns an empty history when nothing has been saved yet', () => {
+    expect(loadEntries()).toEqual([])
+  })
+
+  it('saves a new entry and returns it newest-first', () => {
+    saveEntry({ date: '2026-06-30', weightKg: 70.2, notes: 'Me sentí bien' })
+    const entries = saveEntry({
+      date: '2026-07-01',
+      weightKg: 70.5,
+      notes: ''
+    })
+
+    expect(entries).toEqual([
+      { date: '2026-07-01', weightKg: 70.5, notes: null },
+      { date: '2026-06-30', weightKg: 70.2, notes: 'Me sentí bien' }
+    ])
+  })
+
+  it('upserts the same-day entry instead of creating a duplicate', () => {
+    saveEntry({ date: '2026-07-01', weightKg: 70, notes: 'Primera' })
+    const entries = saveEntry({
+      date: '2026-07-01',
+      weightKg: 71,
+      notes: 'Actualizada'
+    })
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toEqual({
+      date: '2026-07-01',
+      weightKg: 71,
+      notes: 'Actualizada'
+    })
+  })
+
+  it('allows an entry with only weight, only notes, or neither', () => {
+    const entries = saveEntry({ date: '2026-07-01', weightKg: 70.5 })
+    expect(entries[0]).toEqual({
+      date: '2026-07-01',
+      weightKg: 70.5,
+      notes: null
+    })
+
+    const notesOnly = saveEntry({
+      date: '2026-07-02',
+      notes: 'Sin báscula hoy'
+    })
+    expect(notesOnly[0]).toEqual({
+      date: '2026-07-02',
+      weightKg: null,
+      notes: 'Sin báscula hoy'
+    })
+  })
+
+  it('ignores a non-positive or non-numeric weight instead of storing garbage', () => {
+    const entries = saveEntry({ date: '2026-07-01', weightKg: -5, notes: '' })
+    expect(entries[0].weightKg).toBeNull()
+
+    const entries2 = saveEntry({
+      date: '2026-07-02',
+      weightKg: 'setenta',
+      notes: ''
+    })
+    expect(entries2.find((e) => e.date === '2026-07-02').weightKg).toBeNull()
+  })
+
+  it('trims notes and caps them at 140 characters', () => {
+    const longNote = 'a'.repeat(200)
+    const entries = saveEntry({
+      date: '2026-07-01',
+      notes: `  ${longNote}  `
+    })
+
+    expect(entries[0].notes).toHaveLength(140)
+    expect(entries[0].notes).toBe(longNote.slice(0, 140))
+  })
+
+  it('throws only for a missing/invalid date, never for the rest of the payload', () => {
+    expect(() => saveEntry({ date: 'not-a-date' })).toThrow()
+    expect(() => saveEntry({})).toThrow()
+  })
+
+  it('caps history at MAX_ENTRIES, dropping the oldest entries first', () => {
+    const isoDatePlusDays = (offset) => {
+      const base = new Date(2026, 0, 1)
+      base.setDate(base.getDate() + offset)
+      return todayISO(base)
+    }
+
+    const totalDays = MAX_ENTRIES + 5
+    for (let offset = 0; offset < totalDays; offset++) {
+      saveEntry({ date: isoDatePlusDays(offset), weightKg: 70 })
+    }
+
+    const entries = loadEntries()
+    expect(entries).toHaveLength(MAX_ENTRIES)
+    // The 5 oldest days were dropped; the most recent MAX_ENTRIES remain.
+    expect(entries[0].date).toBe(isoDatePlusDays(totalDays - 1))
+    expect(entries[entries.length - 1].date).toBe(isoDatePlusDays(5))
+    expect(
+      entries.some((entry) => entry.date === isoDatePlusDays(0))
+    ).toBe(false)
+  })
+
+  it('never throws on corrupt localStorage JSON and falls back to an empty log', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'not valid json{')
+
+    let entries
+    expect(() => {
+      entries = loadEntries()
+    }).not.toThrow()
+    expect(entries).toEqual([])
+  })
+
+  it('never throws on a malformed-shape stored value and falls back to an empty log', () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ foo: 'bar' }))
+    expect(loadEntries()).toEqual([])
+
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ version: 1, entries: 'not-an-array' })
+    )
+    expect(loadEntries()).toEqual([])
+  })
+
+  it('filters out individually malformed entries without discarding the valid ones', () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          { date: '2026-07-01', weightKg: 70, notes: null },
+          { date: 'bad-date', weightKg: 70, notes: null },
+          { weightKg: 70, notes: null }
+        ]
+      })
+    )
+
+    expect(loadEntries()).toEqual([
+      { date: '2026-07-01', weightKg: 70, notes: null }
+    ])
+  })
+
+  it('clearAll removes the entire log', () => {
+    saveEntry({ date: '2026-07-01', weightKg: 70 })
+    clearAll()
+
+    expect(loadEntries()).toEqual([])
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+})
+
+describe('todayISO', () => {
+  it('formats an injected date as YYYY-MM-DD using local time', () => {
+    expect(todayISO(new Date(2026, 6, 1))).toBe('2026-07-01') // July is month 6
+    expect(todayISO(new Date(2026, 0, 5))).toBe('2026-01-05')
+  })
+})
+
+describe('computeDelta', () => {
+  it('returns null when either entry is missing a weight', () => {
+    expect(
+      computeDelta(
+        { date: '2026-07-01', weightKg: null },
+        { date: '2026-06-30', weightKg: 70 }
+      )
+    ).toBeNull()
+    expect(computeDelta({ date: '2026-07-01', weightKg: 70 }, null)).toBeNull()
+  })
+
+  it('computes the kg difference and whether the previous entry was exactly one day earlier', () => {
+    const delta = computeDelta(
+      { date: '2026-07-01', weightKg: 70.8 },
+      { date: '2026-06-30', weightKg: 70.2 }
+    )
+    expect(delta.kg).toBeCloseTo(0.6, 5)
+    expect(delta.isConsecutiveDay).toBe(true)
+  })
+
+  it('flags a gap of more than one day so the UI does not falsely say "desde ayer"', () => {
+    const delta = computeDelta(
+      { date: '2026-07-05', weightKg: 70 },
+      { date: '2026-06-30', weightKg: 72 }
+    )
+    expect(delta.isConsecutiveDay).toBe(false)
+    expect(delta.kg).toBeCloseTo(-2, 5)
+  })
+})

--- a/src/utils/healthLog.js
+++ b/src/utils/healthLog.js
@@ -1,0 +1,176 @@
+// healthLog: private, on-device daily weight/notes log (design section 7,
+// content-research #5086 section 3c — daily weight monitoring is an
+// IMSS-797-16 self-care checklist item). No accounts, no servers: every
+// entry lives only in this browser's localStorage, under `healthlog:v1`.
+//
+// R5.5 (hard rule): this module stores exactly the raw numbers the user
+// typed. It never judges, flags, or interprets a value as good/bad/normal —
+// no thresholds live here. `computeDelta` below is a plain arithmetic diff
+// between two entries, not a clinical assessment; the UI that consumes it
+// (src/components/HealthLog) is responsible for keeping that framing.
+//
+// Corrupt-data-safe, mirroring src/utils/progressStorage.js's approach:
+// every read path is wrapped so a disabled/unavailable localStorage, invalid
+// JSON, or an unexpected shape falls back to an empty log instead of
+// throwing. History is capped at MAX_ENTRIES (90 days, ~3 months) so a
+// device that never clears its data doesn't grow storage unbounded.
+//
+// Because the PWA offline service worker (PR10, registerServiceWorker.js)
+// precaches the app shell, this page — and the localStorage read/write below
+// — works the same with no network connection; nothing here needed a
+// network round-trip to begin with.
+
+export const STORAGE_KEY = 'healthlog:v1'
+const VERSION = 1
+export const MAX_ENTRIES = 90
+const MAX_NOTES_LENGTH = 140
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+const isValidEntry = (entry) =>
+  typeof entry === 'object' &&
+  entry !== null &&
+  typeof entry.date === 'string' &&
+  DATE_PATTERN.test(entry.date) &&
+  (entry.weightKg === null || typeof entry.weightKg === 'number') &&
+  (entry.notes === null || typeof entry.notes === 'string')
+
+const readEntries = () => {
+  let raw
+  try {
+    raw = window.localStorage.getItem(STORAGE_KEY)
+  } catch (error) {
+    // localStorage unavailable (private mode, disabled, etc.)
+    return []
+  }
+
+  if (!raw) return []
+
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    return []
+  }
+
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    parsed.version !== VERSION ||
+    !Array.isArray(parsed.entries)
+  ) {
+    return []
+  }
+
+  return parsed.entries.filter(isValidEntry)
+}
+
+const writeEntries = (entries) => {
+  try {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ version: VERSION, entries })
+    )
+  } catch (error) {
+    // localStorage unavailable — fail silently, same best-effort contract
+    // as progressStorage.saveProgress.
+  }
+}
+
+const sortDescending = (entries) =>
+  [...entries].sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0))
+
+const normalizeWeight = (weightKg) =>
+  typeof weightKg === 'number' && Number.isFinite(weightKg) && weightKg > 0
+    ? weightKg
+    : null
+
+const normalizeNotes = (notes) => {
+  if (typeof notes !== 'string') return null
+  const trimmed = notes.trim()
+  return trimmed.length > 0 ? trimmed.slice(0, MAX_NOTES_LENGTH) : null
+}
+
+/**
+ * Loads the saved history, newest entry first.
+ * @returns {Array<{date: string, weightKg: number|null, notes: string|null}>}
+ */
+export const loadEntries = () => sortDescending(readEntries())
+
+/**
+ * Saves (or updates, if `date` already has an entry) a single day's log.
+ * One entry per calendar day — saving the same `date` twice replaces the
+ * first entry rather than creating a duplicate.
+ *
+ * @param {{date: string, weightKg?: number, notes?: string}} payload
+ * @returns {Array<{date: string, weightKg: number|null, notes: string|null}>} updated history, newest first
+ */
+export const saveEntry = ({ date, weightKg, notes } = {}) => {
+  if (typeof date !== 'string' || !DATE_PATTERN.test(date)) {
+    throw new Error('[healthLog] saveEntry requires a date in YYYY-MM-DD format')
+  }
+
+  const entry = {
+    date,
+    weightKg: normalizeWeight(weightKg),
+    notes: normalizeNotes(notes)
+  }
+
+  const withoutSameDay = readEntries().filter((existing) => existing.date !== date)
+  const updated = sortDescending([...withoutSameDay, entry]).slice(0, MAX_ENTRIES)
+
+  writeEntries(updated)
+
+  return updated
+}
+
+/** Deletes the entire log — used by the "borrar todo mi registro" action. */
+export const clearAll = () => {
+  try {
+    window.localStorage.removeItem(STORAGE_KEY)
+  } catch (error) {
+    // localStorage unavailable — nothing to clear
+  }
+}
+
+/**
+ * Today's date as YYYY-MM-DD in the device's local time. `now` is
+ * injectable for tests, mirroring registerServiceWorker.js's pattern of
+ * accepting its environment dependencies as parameters.
+ */
+export const todayISO = (now = new Date()) => {
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+// UTC noon avoids DST-related off-by-one errors when diffing two
+// YYYY-MM-DD calendar dates — only whole-day granularity matters here.
+const toUTCNoon = (isoDate) => new Date(`${isoDate}T12:00:00Z`)
+
+/**
+ * Plain arithmetic difference between two entries — NOT a clinical
+ * judgment (R5.5). Returns null when either entry has no weight recorded,
+ * so the UI never renders a delta computed from a missing value.
+ *
+ * @param {{date: string, weightKg: number|null}} current
+ * @param {{date: string, weightKg: number|null}|null} previous
+ * @returns {{kg: number, isConsecutiveDay: boolean}|null}
+ */
+export const computeDelta = (current, previous) => {
+  if (!current || !previous) return null
+  if (typeof current.weightKg !== 'number' || typeof previous.weightKg !== 'number') {
+    return null
+  }
+
+  const msPerDay = 24 * 60 * 60 * 1000
+  const dayGap = Math.round(
+    (toUTCNoon(current.date) - toUTCNoon(previous.date)) / msPerDay
+  )
+
+  return {
+    kg: current.weightKg - previous.weightKg,
+    isConsecutiveDay: dayGap === 1
+  }
+}


### PR DESCRIPTION
Part of #3 (PR11a of the accessible-redesign chain — stacked on #15; split at the natural commit boundary per review guidance)

## Summary

The storage foundation for the daily weight log (inert until PR11b wires the UI — same pattern as progressStorage in PR2/PR3):

- `src/utils/healthLog.js`: localStorage `healthlog:v1`, one entry per day (same-day save = update), 90-day history cap, corrupt-data-safe (never throws)
- `computeDelta` is pure arithmetic — kg difference + consecutive-day flag, explicitly documented as non-clinical
- Local-date entry keying with UTC-pinned display formatting: a patient logging at 11:30 pm in Mexico City gets TODAY's entry, and it displays as the same calendar day (timezone bug reproduced and verified fixed by the independent review)

## Test plan

- [x] 16 dedicated tests: upsert, cap, corrupt v1/legacy data, delta math, date handling
- [x] `npm test` green, `npm run build` passes
- [x] Independent fresh-context review: PASS — 0 critical