### PR TITLE
feat(health-log): daily weight log page at /registro

### DIFF
--- a/__tests__/HealthLog.test.js
+++ b/__tests__/HealthLog.test.js
@@ -1,0 +1,196 @@
+import React from 'react'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { RouteList } from '../src/routes/RouteList'
+import { STORAGE_KEY } from '../src/utils/healthLog'
+
+const renderRegistro = () =>
+  render(
+    <MemoryRouter initialEntries={['/registro']}>
+      <RouteList />
+    </MemoryRouter>
+  )
+
+const seedEntries = (entries) => {
+  window.localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ version: 1, entries })
+  )
+}
+
+// R5.5's hard rule applied to this page: no value-judgment vocabulary about
+// the user's weight anywhere on the page — the log records numbers, it
+// never assesses them as good/bad/normal/dangerous, and it never computes
+// a BMI-style index. Mirrors PR8's FLUID_VOLUME_NUMBER / PR9's MG_NUMBER
+// guard pattern for their own no-invented-threshold rules.
+const VALUE_JUDGMENT_PATTERN =
+  /(peso\s+(est[aá]\s+)?(alto|bajo|excesivo|elevado|ideal|normal|anormal|saludable)|sobrepeso|bajo\s+peso|deber[ií]as\s+(subir|bajar|perder|ganar)|peso\s+peligroso|es\s+(peligroso|malo|grave)\s+que|tu\s+peso\s+est[aá]\s+(bien|mal)|meta\s+de\s+peso|[ií]ndice\s+de\s+masa|\bIMC\b)/i
+
+describe('VALUE_JUDGMENT_PATTERN regex', () => {
+  it('matches known value-judgment phrasings before relying on it to scan the page', () => {
+    expect('tu peso está alto').toMatch(VALUE_JUDGMENT_PATTERN)
+    expect('tienes sobrepeso').toMatch(VALUE_JUDGMENT_PATTERN)
+    expect('deberías bajar de peso').toMatch(VALUE_JUDGMENT_PATTERN)
+    expect('tu IMC es 27').toMatch(VALUE_JUDGMENT_PATTERN)
+    expect('subiste 0.5 kg desde ayer').not.toMatch(VALUE_JUDGMENT_PATTERN)
+  })
+})
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+describe('Registro diario page', () => {
+  it('renders under Layout at /registro with the page title', () => {
+    renderRegistro()
+
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Mi registro diario', level: 1 })
+    ).toBeInTheDocument()
+  })
+
+  it('shows a plain-language empty state when there is no history yet', () => {
+    renderRegistro()
+
+    expect(screen.getByText(/[Aa]ún no tienes registros/)).toBeInTheDocument()
+  })
+
+  it('has labelled (not placeholder-only) weight and note fields', () => {
+    renderRegistro()
+
+    expect(
+      screen.getByLabelText(/Peso de hoy/i)
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText(/[Nn]ota/i)).toBeInTheDocument()
+  })
+
+  it('uses a decimal-friendly numeric input for weight (R6.3, mobile keypad)', () => {
+    renderRegistro()
+
+    const weightInput = screen.getByLabelText(/Peso de hoy/i)
+    expect(weightInput).toHaveAttribute('inputmode', 'decimal')
+  })
+
+  it('saves a new entry and shows it in the history', async () => {
+    const user = userEvent.setup()
+    renderRegistro()
+
+    await user.type(screen.getByLabelText(/Peso de hoy/i), '70.5')
+    await user.type(screen.getByLabelText(/[Nn]ota/i), 'Me sentí bien')
+    await user.click(screen.getByRole('button', { name: /[Gg]uardar registro/i }))
+
+    const history = screen.getByRole('list', { name: /historial/i })
+    expect(within(history).getByText(/70\.5/)).toBeInTheDocument()
+    expect(within(history).getByText('Me sentí bien')).toBeInTheDocument()
+  })
+
+  it('updates (not duplicates) today\'s entry on a second save', async () => {
+    const user = userEvent.setup()
+    renderRegistro()
+
+    await user.type(screen.getByLabelText(/Peso de hoy/i), '70')
+    await user.click(screen.getByRole('button', { name: /[Gg]uardar registro/i }))
+
+    const weightInput = screen.getByLabelText(/Peso de hoy/i)
+    await user.clear(weightInput)
+    await user.type(weightInput, '71')
+    await user.click(screen.getByRole('button', { name: /[Aa]ctualizar registro/i }))
+
+    const history = screen.getByRole('list', { name: /historial/i })
+    expect(within(history).getAllByRole('listitem')).toHaveLength(1)
+    expect(within(history).getByText(/71/)).toBeInTheDocument()
+  })
+
+  it('shows an icon+text delta versus the previous day, not color alone', () => {
+    seedEntries([
+      { date: '2026-06-30', weightKg: 70, notes: null },
+      { date: '2026-07-01', weightKg: 70.8, notes: null }
+    ])
+
+    renderRegistro()
+
+    // Text carries the meaning; an aria-hidden icon accompanies it.
+    expect(screen.getByText(/subiste 0\.8 kg desde ayer/i)).toBeInTheDocument()
+  })
+
+  it('does not claim "desde ayer" when the previous entry is more than one day earlier', () => {
+    seedEntries([
+      { date: '2026-06-20', weightKg: 72, notes: null },
+      { date: '2026-07-01', weightKg: 70, notes: null }
+    ])
+
+    renderRegistro()
+
+    expect(screen.queryByText(/desde ayer/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/desde tu (último|registro) anterior/i)).toBeInTheDocument()
+  })
+
+  it('shows a static clinic-contact reminder that does not change based on the data (R5.5)', () => {
+    renderRegistro()
+    expect(
+      screen.getByText(/sube varios días seguidos|te hinchas más/i)
+    ).toBeInTheDocument()
+    expect(screen.getAllByText(/llama a tu clínica/i).length).toBeGreaterThan(0)
+
+    window.localStorage.clear()
+    seedEntries([
+      { date: '2026-06-25', weightKg: 60, notes: null },
+      { date: '2026-07-01', weightKg: 90, notes: null } // an extreme jump
+    ])
+    renderRegistro()
+    // Same static reminder text — not a data-triggered alert with different wording.
+    expect(
+      screen.getAllByText(/sube varios días seguidos|te hinchas más/i).length
+    ).toBeGreaterThan(0)
+  })
+
+  it('never renders value-judgment language about the user\'s weight, even with a large delta', () => {
+    seedEntries([
+      { date: '2026-06-30', weightKg: 60, notes: null },
+      { date: '2026-07-01', weightKg: 90, notes: null }
+    ])
+
+    renderRegistro()
+
+    const main = screen.getByRole('main')
+    expect(main.textContent).not.toMatch(VALUE_JUDGMENT_PATTERN)
+  })
+
+  it('deletes the whole log after confirmation', async () => {
+    const user = userEvent.setup()
+    seedEntries([{ date: '2026-07-01', weightKg: 70, notes: null }])
+    renderRegistro()
+
+    await user.click(
+      screen.getByRole('button', { name: /borrar todo mi registro/i })
+    )
+    await user.click(screen.getByRole('button', { name: /sí, borrar/i }))
+
+    expect(screen.getByText(/[Aa]ún no tienes registros/)).toBeInTheDocument()
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('cancels the delete-all action without clearing the log', async () => {
+    const user = userEvent.setup()
+    seedEntries([{ date: '2026-07-01', weightKg: 70, notes: null }])
+    renderRegistro()
+
+    await user.click(
+      screen.getByRole('button', { name: /borrar todo mi registro/i })
+    )
+    await user.click(screen.getByRole('button', { name: /cancelar/i }))
+
+    const history = screen.getByRole('list', { name: /historial/i })
+    expect(within(history).getAllByRole('listitem')).toHaveLength(1)
+  })
+
+  it('resolves citations and always shows the clinic/nephrologist disclaimer', () => {
+    renderRegistro()
+
+    expect(
+      screen.getByText(/no reemplaza las indicaciones de tu clínica/)
+    ).toBeInTheDocument()
+  })
+})

--- a/__tests__/Home.test.js
+++ b/__tests__/Home.test.js
@@ -42,6 +42,14 @@ describe('Home', () => {
     ).toHaveAttribute('href', '/realizar-dialisis')
   })
 
+  it('links the daily-log card to /registro (PR11)', () => {
+    renderHome()
+
+    expect(
+      screen.getByRole('link', { name: /Mi registro diario/ })
+    ).toHaveAttribute('href', '/registro')
+  })
+
   it('keeps the daily schedules below the hub sections', () => {
     renderHome()
 

--- a/__tests__/NavBar.test.js
+++ b/__tests__/NavBar.test.js
@@ -70,6 +70,14 @@ describe('NavBar', () => {
     ).toHaveAttribute('aria-current', 'page')
   })
 
+  it('marks Comida y líquidos active on the top-level /registro route', () => {
+    renderNavBar('/registro')
+
+    expect(
+      screen.getByRole('link', { name: /Comida y líquidos/ })
+    ).toHaveAttribute('aria-current', 'page')
+  })
+
   it('does not mark any tab active on an unrelated route', () => {
     renderNavBar('/does-not-exist')
 

--- a/__tests__/RouteList.test.js
+++ b/__tests__/RouteList.test.js
@@ -76,6 +76,14 @@ describe('RouteList', () => {
     expect(screen.queryByText(/preparando esta guía/)).not.toBeInTheDocument()
   })
 
+  it('renders the real Registro diario page at /registro under Layout (PR11)', () => {
+    renderAt('/registro')
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Mi registro diario', level: 1 })
+    ).toBeInTheDocument()
+  })
+
   it('falls back to NoMatch on an unknown route', () => {
     renderAt('/does-not-exist')
     expect(screen.getByRole('main')).toBeInTheDocument()

--- a/src/components/HealthLog/index.js
+++ b/src/components/HealthLog/index.js
@@ -1,0 +1,259 @@
+import React, { useEffect, useState } from 'react'
+import { MdArrowUpward, MdArrowDownward, MdRemove } from 'react-icons/md'
+import { PageContainer } from '../PageContainer'
+import { CitationFooter } from '../CitationFooter'
+import {
+  loadEntries,
+  saveEntry,
+  clearAll,
+  todayISO,
+  computeDelta
+} from '../../utils/healthLog'
+import {
+  IntroText,
+  PrivacyNote,
+  Form,
+  Field,
+  FieldLabel,
+  NumberInput,
+  TextInput,
+  ErrorText,
+  SaveButton,
+  StatusMessage,
+  HistorySection,
+  HistoryList,
+  HistoryItem,
+  HistoryDate,
+  HistoryWeight,
+  HistoryNotes,
+  DeltaRow,
+  DeltaIcon,
+  EmptyState,
+  DeleteAllButton,
+  ModalOverlay,
+  ModalBox,
+  ModalButtons,
+  ConfirmDeleteButton,
+  CancelDeleteButton
+} from './styles'
+
+// HealthLog: private daily weight/notes log — design section 7 sketch,
+// "Weight/fluid log" (PR11, the final optional slice of accessible-redesign).
+// No accounts, no servers: everything reads/writes localStorage via
+// src/utils/healthLog.js. Because the app is offline-capable since PR10
+// (src/utils/registerServiceWorker.js precaches the app shell), this whole
+// page — form, history, and localStorage reads/writes — works the same with
+// no network connection; nothing here required any network-awareness code.
+//
+// R5.5 hard rule for this page (the log's own version of PR8/PR9's "no
+// invented threshold" rule): the log NEVER judges a weight value as
+// good/bad/normal/dangerous, and never computes a derived index like BMI.
+// day-over-day deltas (computeDelta) are plain arithmetic, shown with
+// neutral wording ("subiste"/"bajaste"/"se mantuvo igual"). The one
+// clinic-contact reminder below is a *static* callout (design section 7 +
+// content-research #5086 section 3c, NKF fluid-overload source) — it always
+// renders, regardless of the data, so it can never read as a per-value
+// alert. See __tests__/HealthLog.test.js's VALUE_JUDGMENT_PATTERN guard.
+const formatDate = (isoDate, options) =>
+  new Intl.DateTimeFormat('es-MX', { ...options, timeZone: 'UTC' }).format(
+    new Date(`${isoDate}T00:00:00Z`)
+  )
+
+const formatWeight = (weightKg) => `${weightKg.toFixed(1)} kg`
+
+const DeltaIndicator = ({ current, previous }) => {
+  const delta = computeDelta(current, previous)
+  if (!delta) return null
+
+  const rounded = Math.round(Math.abs(delta.kg) * 10) / 10
+  const when = delta.isConsecutiveDay
+    ? 'desde ayer'
+    : `desde tu registro anterior (${formatDate(previous.date, { day: 'numeric', month: 'long' })})`
+
+  if (rounded === 0) {
+    return (
+      <DeltaRow>
+        <DeltaIcon aria-hidden='true'><MdRemove /></DeltaIcon>
+        <span>Tu peso se mantuvo igual {when}</span>
+      </DeltaRow>
+    )
+  }
+
+  const verb = delta.kg > 0 ? 'subiste' : 'bajaste'
+  const Icon = delta.kg > 0 ? MdArrowUpward : MdArrowDownward
+
+  return (
+    <DeltaRow>
+      <DeltaIcon aria-hidden='true'><Icon /></DeltaIcon>
+      <span>{verb} {rounded.toFixed(1)} kg {when}</span>
+    </DeltaRow>
+  )
+}
+
+export const HealthLog = () => {
+  const [entries, setEntries] = useState([])
+  const [weightValue, setWeightValue] = useState('')
+  const [notesValue, setNotesValue] = useState('')
+  const [error, setError] = useState(null)
+  const [status, setStatus] = useState(null)
+  const [showConfirmDelete, setShowConfirmDelete] = useState(false)
+
+  const today = todayISO()
+
+  useEffect(() => {
+    const loaded = loadEntries()
+    setEntries(loaded)
+
+    const todayEntry = loaded.find((entry) => entry.date === today)
+    if (todayEntry) {
+      setWeightValue(todayEntry.weightKg != null ? String(todayEntry.weightKg) : '')
+      setNotesValue(todayEntry.notes || '')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const hasTodayEntry = entries.some((entry) => entry.date === today)
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    setError(null)
+
+    const trimmedWeight = weightValue.trim()
+    let weightKg
+    if (trimmedWeight === '') {
+      weightKg = undefined
+    } else {
+      const parsed = Number(trimmedWeight)
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        setError('Ingresa un peso válido en kilogramos, por ejemplo 70.5.')
+        return
+      }
+      weightKg = parsed
+    }
+
+    const updated = saveEntry({ date: today, weightKg, notes: notesValue })
+    setEntries(updated)
+    setStatus(hasTodayEntry ? 'Registro actualizado.' : 'Registro guardado.')
+  }
+
+  const handleConfirmDelete = () => {
+    clearAll()
+    setEntries([])
+    setWeightValue('')
+    setNotesValue('')
+    setShowConfirmDelete(false)
+    setStatus(null)
+  }
+
+  return (
+    <PageContainer>
+      <IntroText>
+        Aquí puedes anotar tu peso y cómo te sientes cada día. Pesarte todos
+        los días, a la misma hora, es parte del autocuidado en diálisis
+        peritoneal y ayuda a ti y a tu clínica a detectar cambios a tiempo.
+      </IntroText>
+      <PrivacyNote>
+        Tu información se guarda únicamente en este teléfono; no se envía a
+        internet ni se comparte con nadie. Como esta app funciona sin
+        conexión, puedes usar tu registro aunque no tengas internet.
+      </PrivacyNote>
+
+      <h2>{hasTodayEntry ? 'Actualiza el registro de hoy' : 'Registra tu peso de hoy'}</h2>
+      <Form onSubmit={handleSubmit} aria-label='Formulario de registro diario'>
+        <Field>
+          <FieldLabel htmlFor='health-log-weight'>Peso de hoy (kg)</FieldLabel>
+          <NumberInput
+            id='health-log-weight'
+            type='number'
+            inputMode='decimal'
+            step='0.1'
+            min='0'
+            value={weightValue}
+            onChange={(event) => setWeightValue(event.target.value)}
+            aria-describedby={error ? 'health-log-weight-error' : undefined}
+          />
+          {error && <ErrorText id='health-log-weight-error'>{error}</ErrorText>}
+        </Field>
+
+        <Field>
+          <FieldLabel htmlFor='health-log-notes'>Nota (opcional)</FieldLabel>
+          <TextInput
+            id='health-log-notes'
+            type='text'
+            maxLength={140}
+            value={notesValue}
+            onChange={(event) => setNotesValue(event.target.value)}
+          />
+        </Field>
+
+        <SaveButton type='submit'>
+          {hasTodayEntry ? 'Actualizar registro de hoy' : 'Guardar registro de hoy'}
+        </SaveButton>
+
+        {status && <StatusMessage role='status'>{status}</StatusMessage>}
+      </Form>
+
+      <HistorySection aria-labelledby='health-log-history-heading'>
+        <h2 id='health-log-history-heading'>Tu historial</h2>
+
+        {entries.length === 0
+          ? (
+            <EmptyState>
+              Aún no tienes registros. Pesarte todos los días te ayuda, junto
+              con tu clínica, a detectar cambios en tu retención de líquido.
+            </EmptyState>
+            )
+          : (
+            <HistoryList aria-label='Historial de registros'>
+              {entries.map((entry, index) => (
+                <HistoryItem key={entry.date}>
+                  <HistoryDate>
+                    {formatDate(entry.date, { day: 'numeric', month: 'long', year: 'numeric' })}
+                  </HistoryDate>
+                  {entry.weightKg != null && (
+                    <HistoryWeight>{formatWeight(entry.weightKg)}</HistoryWeight>
+                  )}
+                  <DeltaIndicator current={entry} previous={entries[index + 1]} />
+                  {entry.notes && <HistoryNotes>{entry.notes}</HistoryNotes>}
+                </HistoryItem>
+              ))}
+            </HistoryList>
+            )}
+      </HistorySection>
+
+      {/* Static reminder, R5.6-style non-behavioral framing but for this
+          page's own rule (R5.5): always renders, regardless of the data —
+          never a per-value alert triggered by a specific weight/delta. */}
+      <IntroText>
+        Si notas que tu peso sube varios días seguidos o te hinchas más,
+        llama a tu clínica. No es necesario esperar a que un número te
+        parezca "muy alto" para preguntar.
+      </IntroText>
+
+      {entries.length > 0 && (
+        <DeleteAllButton type='button' onClick={() => setShowConfirmDelete(true)}>
+          Borrar todo mi registro
+        </DeleteAllButton>
+      )}
+
+      {showConfirmDelete && (
+        <ModalOverlay onClick={() => setShowConfirmDelete(false)}>
+          <ModalBox onClick={(event) => event.stopPropagation()} role='dialog' aria-modal='true' aria-labelledby='health-log-delete-heading'>
+            <h3 id='health-log-delete-heading'>¿Borrar todo tu registro?</h3>
+            <p>Esta acción borra todos los días guardados en este teléfono y no se puede deshacer.</p>
+            <ModalButtons>
+              <CancelDeleteButton type='button' onClick={() => setShowConfirmDelete(false)}>
+                Cancelar
+              </CancelDeleteButton>
+              <ConfirmDeleteButton type='button' onClick={handleConfirmDelete}>
+                Sí, borrar todo
+              </ConfirmDeleteButton>
+            </ModalButtons>
+          </ModalBox>
+        </ModalOverlay>
+      )}
+
+      <CitationFooter sourceIds={['imss-797-16', 'nkf-fluid-overload']} />
+    </PageContainer>
+  )
+}

--- a/src/components/HealthLog/styles.js
+++ b/src/components/HealthLog/styles.js
@@ -1,0 +1,226 @@
+import styled from 'styled-components'
+
+export const IntroText = styled.p`
+  color: var(--color-secondary);
+  line-height: 1.6;
+  margin-bottom: var(--spacing-sm);
+`
+
+export const PrivacyNote = styled.p`
+  color: var(--color-secondary);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+`
+
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  margin: var(--spacing-md) 0;
+`
+
+export const Field = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+`
+
+export const FieldLabel = styled.label`
+  font-weight: 600;
+  color: var(--color-primary);
+  font-size: var(--font-size-base);
+`
+
+export const NumberInput = styled.input`
+  min-height: 48px; /* Área de toque grande — R6.3 */
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  font-size: var(--font-size-lg);
+  background: var(--body-background);
+  color: var(--color-primary);
+  max-width: 220px;
+`
+
+export const TextInput = styled.input`
+  min-height: 48px; /* Área de toque grande — R6.3 */
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  font-size: var(--font-size-base);
+  background: var(--body-background);
+  color: var(--color-primary);
+`
+
+export const ErrorText = styled.p`
+  color: var(--color-warning);
+  font-size: var(--font-size-sm);
+`
+
+export const SaveButton = styled.button`
+  align-self: flex-start;
+  min-height: 48px;
+  padding: var(--spacing-sm) var(--spacing-xl);
+  border-radius: var(--border-radius);
+  background: var(--color-accent);
+  color: white;
+  font-weight: 600;
+  font-size: var(--font-size-base);
+
+  &:hover {
+    background: var(--color-primary);
+  }
+
+  @media (max-width: 480px) {
+    align-self: stretch;
+  }
+`
+
+export const StatusMessage = styled.p`
+  color: var(--color-actived);
+  font-weight: 600;
+`
+
+export const HistorySection = styled.section`
+  margin-top: var(--spacing-lg);
+`
+
+export const HistoryList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-sm);
+`
+
+export const HistoryItem = styled.li`
+  padding: var(--spacing-md);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  background: var(--body-background);
+`
+
+export const HistoryDate = styled.p`
+  font-weight: 600;
+  color: var(--color-primary);
+`
+
+export const HistoryWeight = styled.p`
+  color: var(--color-primary);
+  font-size: var(--font-size-lg);
+`
+
+export const HistoryNotes = styled.p`
+  color: var(--color-secondary);
+  font-size: var(--font-size-sm);
+  margin-top: var(--spacing-xs);
+`
+
+export const DeltaRow = styled.p`
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  color: var(--color-secondary);
+  font-size: var(--font-size-sm);
+  margin-top: var(--spacing-xs);
+`
+
+export const DeltaIcon = styled.span`
+  display: inline-flex;
+  color: var(--color-secondary);
+`
+
+export const EmptyState = styled.p`
+  color: var(--color-secondary);
+  line-height: 1.6;
+  padding: var(--spacing-md) 0;
+`
+
+export const DeleteAllButton = styled.button`
+  min-height: 44px;
+  margin-top: var(--spacing-lg);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border-radius: var(--border-radius);
+  color: var(--color-warning);
+  border: 1px solid var(--color-warning);
+  font-weight: 600;
+
+  &:hover {
+    background: var(--color-warning);
+    color: white;
+  }
+`
+
+/* Delete-all confirmation modal — same visual pattern as ProgressStep's
+   reset-confirmation modal (src/components/ProgressStep/styles.js), scoped
+   locally here since the two aren't otherwise related. */
+export const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+`
+
+export const ModalBox = styled.div`
+  background: var(--body-card);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-medium);
+  padding: var(--spacing-xl);
+  margin: var(--spacing-md);
+  max-width: 400px;
+  width: 100%;
+  text-align: center;
+
+  h3 {
+    color: var(--color-warning);
+    margin-bottom: var(--spacing-md);
+  }
+
+  p {
+    color: var(--color-secondary);
+    margin-bottom: var(--spacing-sm);
+    line-height: 1.6;
+  }
+`
+
+export const ModalButtons = styled.div`
+  display: flex;
+  gap: var(--spacing-md);
+  justify-content: center;
+  margin-top: var(--spacing-md);
+
+  @media (max-width: 480px) {
+    flex-direction: column;
+  }
+`
+
+export const ConfirmDeleteButton = styled.button`
+  min-height: 44px;
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border-radius: var(--border-radius);
+  background: var(--color-warning);
+  color: white;
+  font-weight: 600;
+
+  &:hover {
+    background: #b91c1c;
+  }
+`
+
+export const CancelDeleteButton = styled.button`
+  min-height: 44px;
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border-radius: var(--border-radius);
+  background: var(--color-secondary);
+  color: white;
+  font-weight: 600;
+
+  &:hover {
+    background: var(--color-primary);
+  }
+`

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -45,7 +45,10 @@ const NAV_ITEMS = [
     label: 'Comida y líquidos',
     ariaLabel: 'Comida y líquidos',
     Icon: MdRestaurant,
-    prefixes: ['/alimentacion']
+    // '/registro' (the daily weight/fluid log, PR11) is a top-level route
+    // like the legacy procedure routes above, but conceptually belongs to
+    // this group — included here for the same active-tab-continuity reason.
+    prefixes: ['/alimentacion', '/registro']
   }
 ]
 

--- a/src/content/navigation.js
+++ b/src/content/navigation.js
@@ -4,7 +4,8 @@ import {
   GiWaterRecycling,
   GiMedicines,
   GiWaterDrop,
-  GiFruitBowl
+  GiFruitBowl,
+  GiWeightScale
 } from 'react-icons/gi'
 import { MdWarningAmber } from 'react-icons/md'
 import { aseoGeneral } from './procedures/aseo-general'
@@ -62,5 +63,18 @@ export const alimentacionLinks = [
     title: 'Nutrición',
     description: 'Alimentación saludable para diálisis peritoneal.',
     icon: GiFruitBowl
+  },
+  {
+    // Route is a top-level `/registro` (design section 7 sketch), not
+    // nested under /alimentacion — same pattern as the 3 legacy procedure
+    // routes, which live outside /procedimientos but still appear in the
+    // Procedimientos hub group and nav tab (see NavBar's comment). This
+    // single navigation.js entry supplies both required entry points
+    // (Home hub card + /alimentacion index card) since both pages already
+    // render this array — no per-page wiring needed.
+    to: '/registro',
+    title: 'Mi registro diario',
+    description: 'Anota tu peso y notas cada día, solo en tu teléfono.',
+    icon: GiWeightScale
   }
 ]

--- a/src/pages/RegistroDiario.js
+++ b/src/pages/RegistroDiario.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Layout } from '../components/Layout'
+import { HealthLog } from '../components/HealthLog'
+
+// RegistroDiario: real page at /registro (PR11, optional slice — design
+// section 7 sketch). Layout provides the skip-link landmark (R6.2) and the
+// page's <h1>; HealthLog owns the form, history, and delete-all state.
+export const RegistroDiario = () => (
+  <Layout
+    title='Mi registro diario'
+    description='Anota tu peso y notas cada día. Tus datos se quedan solo en tu teléfono.'
+  >
+    <HealthLog />
+  </Layout>
+)

--- a/src/routes/RouteList.js
+++ b/src/routes/RouteList.js
@@ -11,6 +11,7 @@ import { Higiene } from '../pages/Higiene'
 import { SenalesAlarma } from '../pages/SenalesAlarma'
 import { Liquidos } from '../pages/Liquidos'
 import { Nutricion } from '../pages/Nutricion'
+import { RegistroDiario } from '../pages/RegistroDiario'
 import { NoMatch } from '../pages/NoMatch'
 
 // Extracted from routes/index.js (which also wraps BrowserRouter + NavBar)
@@ -34,6 +35,10 @@ export const RouteList = () => (
     <Route path='/alimentacion' element={<AlimentacionIndex />} />
     <Route path='/alimentacion/liquidos' element={<Liquidos />} />
     <Route path='/alimentacion/nutricion' element={<Nutricion />} />
+
+    {/* Top-level route (design section 7 sketch), like the legacy
+        procedure routes above — not nested under /alimentacion — PR11 */}
+    <Route path='/registro' element={<RegistroDiario />} />
 
     <Route path='*' element={<NoMatch />} />
   </Routes>


### PR DESCRIPTION
Part of #3 (PR11b of the accessible-redesign chain — stacked on #16; FINAL slice of the chain)

## Summary

The private daily weight & fluid log at `/registro`:

- **Entry form**: today's weight (decimal-friendly numeric keyboard on mobile) + optional short note; real visible labels, 48px targets
- **History**: newest first, with an honest trend line — "subiste/bajaste X.X kg desde ayer", or "desde tu registro anterior (fecha)" when the previous entry wasn't yesterday (it never lies about the comparison window)
- **The app NEVER judges values** (spec R5.5): no thresholds, no value-triggered alerts or colors — verified by a test that seeds a 30 kg jump and asserts the UI stays neutral, plus a judgment-string guard with meta-test. Instead, a STATIC sourced reminder: weight rising several days in a row or more swelling → call your clinic (NKF)
- **Privacy**: everything stays on the device — no accounts, no servers; "borrar todo mi registro" behind a real confirmation dialog
- Entry points: hub card under "Comida y líquidos" + /alimentacion index card — nav stays at exactly 4 tabs
- Works offline automatically thanks to the PR10 service worker

## Test plan

- [x] 30 new tests (form flow, render, no-judgment guards, accessibility structure); suite 164/164 green
- [x] `npm run build` passes
- [x] Independent fresh-context review: PASS — 0 critical (timezone repro, no-judgment audit, nav-tab count all verified)

## Chain complete 🎉

With this PR, the accessible-redesign chain (#4 → #16 → this) is fully delivered: safe fixes, test safety net, content schema migration (107 steps), hub navigation, content primitives, four source-attributed medical topics, offline support, and the daily log.